### PR TITLE
Minor post-transfer changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: rust
+
+matrix:
+  include:
+    - rust: 1.27.0
+    - rust: stable
+    - rust: nightly
+    - rust: stable
+
+script:
+  - cargo test --verbose --all --release
+
+cache: cargo

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ matrix:
     - rust: 1.27.0
     - rust: stable
     - rust: nightly
-    - rust: stable
 
 script:
   - cargo test --verbose --all --release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "rsa"
 version = "0.1.0"
-authors = ["dignifiedquire <dignifiedquire@gmail.com>"]
-description = "RSA implementation in Rust"
+authors = ["RustCrypto Developers", "dignifiedquire <dignifiedquire@gmail.com>"]
+description = "Pure Rust RSA implementation"
 license = "MIT OR Apache-2.0"
-homepage = "https://github.com/dignifiedquire/rust-rsa"
-repository = "https://github.com/dignifiedquire/rust-rsa"
-
+documentation = "https://docs.rs/rsa"
+repository = "https://github.com/RustCrypto/RSA"
 keywords = ["rsa", "encryption", "security", "crypto"]
+categories = ["cryptography"]
 
 [dependencies]
 num-bigint-dig = { version = "0.2", features = ["rand", "i128", "u64_digit"] }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # RSA
+[![crates.io](https://img.shields.io/crates/v/rsa.svg)](https://crates.io/crates/rsa) [![Documentation](https://docs.rs/rsa/badge.svg)](https://docs.rs/rsa) [![Build Status](https://travis-ci.org/RustCrypto/rsa.svg?branch=master)](https://travis-ci.org/RustCrypto/rsa) [![dependency status](https://deps.rs/repo/github/RustCrypto/rsa/status.svg)](https://deps.rs/repo/github/RustCrypto/rsa)
 
-> A portable RSA implementation in Rust.
+A portable RSA implementation in pure Rust.
 
 :warning: **WARNING:** This library has __not__ been audited, so please do not use for production code.
 

--- a/README.md
+++ b/README.md
@@ -32,4 +32,15 @@ There will be three phases before `1.0` :ship: can be released.
 
 ## License
 
-MIT or Apache 2.0
+Licensed under either of
+
+ * [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+ * [MIT license](http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # RSA
-[![crates.io](https://img.shields.io/crates/v/rsa.svg)](https://crates.io/crates/rsa) [![Documentation](https://docs.rs/rsa/badge.svg)](https://docs.rs/rsa) [![Build Status](https://travis-ci.org/RustCrypto/rsa.svg?branch=master)](https://travis-ci.org/RustCrypto/rsa) [![dependency status](https://deps.rs/repo/github/RustCrypto/rsa/status.svg)](https://deps.rs/repo/github/RustCrypto/rsa)
+[![crates.io](https://img.shields.io/crates/v/rsa.svg)](https://crates.io/crates/rsa) [![Documentation](https://docs.rs/rsa/badge.svg)](https://docs.rs/rsa) [![Build Status](https://travis-ci.org/RustCrypto/RSA.svg?branch=master)](https://travis-ci.org/RustCrypto/RSA) [![dependency status](https://deps.rs/repo/github/RustCrypto/RSA/status.svg)](https://deps.rs/repo/github/RustCrypto/RSA)
 
 A portable RSA implementation in pure Rust.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc(html_logo_url =
+    "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 extern crate num_bigint_dig as num_bigint;
 extern crate num_integer;
 extern crate num_traits;


### PR DESCRIPTION
Not sure about the minimum supported Rust version for CI, for now it's 1.27.