### PR TITLE
fix(decryption): ensure values are positive 

### DIFF
--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -96,7 +96,7 @@ pub fn generate_multi_prime_key<R: Rng>(
             continue 'next;
         }
 
-        let exp = BigUint::from_u64(EXP).unwrap();
+        let exp = BigUint::from_u64(EXP).expect("invalid static exponent");
         if let Some(d) = exp.mod_inverse(totient) {
             n_final = n;
             d_final = d;
@@ -106,7 +106,7 @@ pub fn generate_multi_prime_key<R: Rng>(
 
     Ok(RSAPrivateKey::from_components(
         n_final,
-        BigUint::from_u64(EXP).unwrap(),
+        BigUint::from_u64(EXP).expect("invalid static exponent"),
         d_final,
         primes,
     ))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
-#![doc(html_logo_url =
-    "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 extern crate num_bigint_dig as num_bigint;
 extern crate num_integer;
 extern crate num_traits;


### PR DESCRIPTION
When decrypting, care has to be taken to ensure that negative numbers are brought back into the positive range. 

In most cases the `if < 0 then += prime` was enough, but if the number was more negative than the prime, we ended up with still a negative number. So this was changed to use a `while` statement, which ensures the right thing always happens. 


Fixes #2 