### PR TITLE
Splitting blind and unblind into their own functions, exposing raw RSA functions via `internals` module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,4 @@ name = "key"
 default = []
 nightly = ["subtle/nightly", "clear_on_drop/nightly"]
 serde1 = ["num-bigint/serde", "serde"]
+expose-internals = []

--- a/src/danger.rs
+++ b/src/danger.rs
@@ -1,0 +1,6 @@
+pub use crate::key::blind;
+pub use crate::key::check_public;
+pub use crate::key::decrypt;
+pub use crate::key::decrypt_and_check;
+pub use crate::key::encrypt;
+pub use crate::key::unblind;

--- a/src/danger.rs
+++ b/src/danger.rs
@@ -1,6 +1,0 @@
-pub use crate::key::blind;
-pub use crate::key::check_public;
-pub use crate::key::decrypt;
-pub use crate::key::decrypt_and_check;
-pub use crate::key::encrypt;
-pub use crate::key::unblind;

--- a/src/internals.rs
+++ b/src/internals.rs
@@ -1,0 +1,162 @@
+use errors::{Error, Result};
+use key::{PublicKey, RSAPrivateKey};
+use num_bigint::{BigInt, BigUint, ModInverse, RandBigInt, Sign::Plus};
+use num_traits::{One, Signed, Zero};
+use rand::Rng;
+
+/// Raw RSA encryption of m with the public key. No padding is performed.
+#[inline]
+pub fn encrypt<K: PublicKey>(key: &K, m: &BigUint) -> BigUint {
+  m.modpow(key.e(), key.n())
+}
+
+/// Performs raw RSA decryption with no padding, resulting in a plaintext `BigUint`.
+/// Peforms RSA blinding if an `Rng` is passed.
+#[inline]
+pub fn decrypt<R: Rng>(
+  mut rng: Option<&mut R>,
+  priv_key: &RSAPrivateKey,
+  c: &BigUint,
+) -> Result<BigUint> {
+  if c >= priv_key.n() {
+    return Err(Error::Decryption);
+  }
+
+  if priv_key.n().is_zero() {
+    return Err(Error::Decryption);
+  }
+
+  let mut ir = None;
+  let c = if let Some(ref mut rng) = rng {
+    let (blinded, unblinder) = blind(rng, priv_key, c);
+    ir = Some(unblinder);
+    blinded
+  } else {
+    c.clone()
+  };
+
+  let m = match priv_key.precomputed {
+    None => c.modpow(priv_key.d(), priv_key.n()),
+    Some(ref precomputed) => {
+      // We have the precalculated values needed for the CRT.
+
+      let p = &priv_key.primes()[0];
+      let q = &priv_key.primes()[1];
+
+      let mut m = BigInt::from_biguint(Plus, c.modpow(&precomputed.dp, p));
+      let mut m2 = BigInt::from_biguint(Plus, c.modpow(&precomputed.dq, q));
+
+      m -= &m2;
+
+      // clones make me sad :(
+      let primes: Vec<_> = priv_key
+        .primes()
+        .iter()
+        .map(|v| BigInt::from_biguint(Plus, v.clone()))
+        .collect();
+
+      while m.is_negative() {
+        m += &primes[0];
+      }
+      m *= &precomputed.qinv;
+      m %= &primes[0];
+      m *= &primes[1];
+      m += m2;
+
+      let c = BigInt::from_biguint(Plus, c);
+      for (i, value) in precomputed.crt_values.iter().enumerate() {
+        let prime = &primes[2 + i];
+        m2 = c.modpow(&value.exp, prime);
+        m2 -= &m;
+        m2 *= &value.coeff;
+        m2 %= prime;
+        while m2.is_negative() {
+          m2 += prime;
+        }
+        m2 *= &value.r;
+        m += &m2;
+      }
+
+      m.to_biguint().expect("failed to decrypt")
+    }
+  };
+
+  match ir {
+    Some(ref ir) => {
+      // unblind
+      Ok(unblind(priv_key, &m, &ir))
+    }
+    None => Ok(m),
+  }
+}
+
+/// Performs RSA decryption, resulting in a plaintext `BigUint`.
+/// Peforms RSA blinding if an `Rng` is passed.
+/// This will also check for errors in the CRT computation.
+#[inline]
+pub fn decrypt_and_check<R: Rng>(
+  rng: Option<&mut R>,
+  priv_key: &RSAPrivateKey,
+  c: &BigUint,
+) -> Result<BigUint> {
+  let m = decrypt(rng, priv_key, c)?;
+
+  // In order to defend against errors in the CRT computation, m^e is
+  // calculated, which should match the original ciphertext.
+  let check = encrypt(priv_key, &m);
+  if c != &check {
+    return Err(Error::Internal);
+  }
+
+  Ok(m)
+}
+
+/// Returns the blinded c, along with the unblinding factor.
+pub fn blind<R: Rng>(rng: &mut R, priv_key: &RSAPrivateKey, c: &BigUint) -> (BigUint, BigUint) {
+  // Blinding involves multiplying c by r^e.
+  // Then the decryption operation performs (m^e * r^e)^d mod n
+  // which equals mr mod n. The factor of r can then be removed
+  // by multiplying by the multiplicative inverse of r.
+
+  let mut r: BigUint;
+  let mut ir: Option<BigInt>;
+  let unblinder;
+  loop {
+    r = rng.gen_biguint_below(priv_key.n());
+    if r.is_zero() {
+      r = BigUint::one();
+    }
+    ir = r.clone().mod_inverse(priv_key.n());
+    if let Some(ir) = ir {
+      if let Some(ub) = ir.to_biguint() {
+        unblinder = ub;
+        break;
+      }
+    }
+  }
+
+  let e = priv_key.e();
+  let rpowe = r.modpow(&e, priv_key.n()); // N != 0
+  let c = (c * &rpowe) % priv_key.n();
+
+  (c, unblinder)
+}
+
+/// Given an m and and unblinding factor, unblind the m.
+pub fn unblind(priv_key: &RSAPrivateKey, m: &BigUint, unblinder: &BigUint) -> BigUint {
+  (m * unblinder) % priv_key.n()
+}
+
+/// Returns a new vector of the given length, with 0s left padded.
+#[inline]
+pub fn left_pad(input: &[u8], size: usize) -> Vec<u8> {
+  let n = if input.len() > size {
+    size
+  } else {
+    input.len()
+  };
+
+  let mut out = vec![0u8; size];
+  out[size - n..].copy_from_slice(input);
+  out
+}

--- a/src/key.rs
+++ b/src/key.rs
@@ -442,7 +442,7 @@ pub fn check_public(public_key: &impl PublicKey) -> Result<()> {
     Ok(())
 }
 
-/// Raw RSA encryption of m with the public key.
+/// Raw RSA encryption of m with the public key. No padding is performed.
 #[inline]
 pub fn encrypt<K: PublicKey>(key: &K, m: &BigUint) -> BigUint {
     m.modpow(key.e(), key.n())
@@ -484,7 +484,7 @@ pub fn unblind(priv_key: &RSAPrivateKey, m: &BigUint, unblinder: &BigUint) -> Bi
     (m * unblinder) % priv_key.n()
 }
 
-/// Performs raw RSA decryption, resulting in a plaintext `BigUint`.
+/// Performs raw RSA decryption with no padding, resulting in a plaintext `BigUint`.
 /// Peforms RSA blinding if an `Rng` is passed.
 #[inline]
 pub fn decrypt<R: Rng>(

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,8 +1,8 @@
 use clear_on_drop::clear::Clear;
 use num_bigint::traits::ModInverse;
 use num_bigint::Sign::Plus;
-use num_bigint::{BigInt, BigUint, RandBigInt};
-use num_traits::{FromPrimitive, One, Signed, Zero};
+use num_bigint::{BigInt, BigUint};
+use num_traits::{FromPrimitive, One};
 use rand::{Rng, ThreadRng};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
@@ -40,7 +40,7 @@ pub struct RSAPrivateKey {
     primes: Vec<BigUint>,
     /// precomputed values to speed up private operations
     #[cfg_attr(feature = "serde1", serde(skip))]
-    precomputed: Option<PrecomputedValues>,
+    pub(crate) precomputed: Option<PrecomputedValues>,
 }
 
 impl PartialEq for RSAPrivateKey {
@@ -62,19 +62,19 @@ impl Drop for RSAPrivateKey {
 }
 
 #[derive(Debug, Clone)]
-struct PrecomputedValues {
+pub(crate) struct PrecomputedValues {
     /// D mod (P-1)
-    dp: BigUint,
+    pub(crate) dp: BigUint,
     /// D mod (Q-1)
-    dq: BigUint,
+    pub(crate) dq: BigUint,
     /// Q^-1 mod P
-    qinv: BigInt,
+    pub(crate) qinv: BigInt,
 
     /// CRTValues is used for the 3rd and subsequent primes. Due to a
     /// historical accident, the CRT for the first two primes is handled
     /// differently in PKCS#1 and interoperability is sufficiently
     /// important that we mirror this.
-    crt_values: Vec<CRTValue>,
+    pub(crate) crt_values: Vec<CRTValue>,
 }
 
 impl Drop for PrecomputedValues {
@@ -89,13 +89,13 @@ impl Drop for PrecomputedValues {
 
 /// Contains the precomputed Chinese remainder theorem values.
 #[derive(Debug, Clone)]
-struct CRTValue {
+pub(crate) struct CRTValue {
     /// D mod (prime - 1)
-    exp: BigInt,
+    pub(crate) exp: BigInt,
     /// R·Coeff ≡ 1 mod Prime.
-    coeff: BigInt,
+    pub(crate) coeff: BigInt,
     /// product of primes prior to this (inc p and q)
-    r: BigInt,
+    pub(crate) r: BigInt,
 }
 
 impl From<RSAPrivateKey> for RSAPublicKey {
@@ -442,166 +442,10 @@ pub fn check_public(public_key: &impl PublicKey) -> Result<()> {
     Ok(())
 }
 
-/// Raw RSA encryption of m with the public key. No padding is performed.
-#[inline]
-pub fn encrypt<K: PublicKey>(key: &K, m: &BigUint) -> BigUint {
-    m.modpow(key.e(), key.n())
-}
-
-/// Returns the blinded c, along with the unblinding factor.
-pub fn blind<R: Rng>(rng: &mut R, priv_key: &RSAPrivateKey, c: &BigUint) -> (BigUint, BigUint) {
-    // Blinding involves multiplying c by r^e.
-    // Then the decryption operation performs (m^e * r^e)^d mod n
-    // which equals mr mod n. The factor of r can then be removed
-    // by multiplying by the multiplicative inverse of r.
-
-    let mut r: BigUint;
-    let mut ir: Option<BigInt>;
-    let unblinder;
-    loop {
-        r = rng.gen_biguint_below(priv_key.n());
-        if r.is_zero() {
-            r = BigUint::one();
-        }
-        ir = r.clone().mod_inverse(priv_key.n());
-        if let Some(ir) = ir {
-            if let Some(ub) = ir.to_biguint() {
-                unblinder = ub;
-                break;
-            }
-        }
-    }
-
-    let e = priv_key.e();
-    let rpowe = r.modpow(&e, priv_key.n()); // N != 0
-    let c = (c * &rpowe) % priv_key.n();
-
-    (c, unblinder)
-}
-
-/// Given an m and and unblinding factor, unblind the m.
-pub fn unblind(priv_key: &RSAPrivateKey, m: &BigUint, unblinder: &BigUint) -> BigUint {
-    (m * unblinder) % priv_key.n()
-}
-
-/// Performs raw RSA decryption with no padding, resulting in a plaintext `BigUint`.
-/// Peforms RSA blinding if an `Rng` is passed.
-#[inline]
-pub fn decrypt<R: Rng>(
-    mut rng: Option<&mut R>,
-    priv_key: &RSAPrivateKey,
-    c: &BigUint,
-) -> Result<BigUint> {
-    if c >= priv_key.n() {
-        return Err(Error::Decryption);
-    }
-
-    if priv_key.n().is_zero() {
-        return Err(Error::Decryption);
-    }
-
-    let mut ir = None;
-    let c = if let Some(ref mut rng) = rng {
-        let (blinded, unblinder) = blind(rng, priv_key, c);
-        ir = Some(unblinder);
-        blinded
-    } else {
-        c.clone()
-    };
-
-    let m = match priv_key.precomputed {
-        None => c.modpow(priv_key.d(), priv_key.n()),
-        Some(ref precomputed) => {
-            // We have the precalculated values needed for the CRT.
-
-            let p = &priv_key.primes[0];
-            let q = &priv_key.primes[1];
-
-            let mut m = BigInt::from_biguint(Plus, c.modpow(&precomputed.dp, p));
-            let mut m2 = BigInt::from_biguint(Plus, c.modpow(&precomputed.dq, q));
-
-            m -= &m2;
-
-            // clones make me sad :(
-            let primes: Vec<_> = priv_key
-                .primes
-                .iter()
-                .map(|v| BigInt::from_biguint(Plus, v.clone()))
-                .collect();
-
-            while m.is_negative() {
-                m += &primes[0];
-            }
-            m *= &precomputed.qinv;
-            m %= &primes[0];
-            m *= &primes[1];
-            m += m2;
-
-            let c = BigInt::from_biguint(Plus, c);
-            for (i, value) in precomputed.crt_values.iter().enumerate() {
-                let prime = &primes[2 + i];
-                m2 = c.modpow(&value.exp, prime);
-                m2 -= &m;
-                m2 *= &value.coeff;
-                m2 %= prime;
-                while m2.is_negative() {
-                    m2 += prime;
-                }
-                m2 *= &value.r;
-                m += &m2;
-            }
-
-            m.to_biguint().expect("failed to decrypt")
-        }
-    };
-
-    match ir {
-        Some(ref ir) => {
-            // unblind
-            Ok(unblind(priv_key, &m, &ir))
-        }
-        None => Ok(m),
-    }
-}
-
-/// Performs RSA decryption, resulting in a plaintext `BigUint`.
-/// Peforms RSA blinding if an `Rng` is passed.
-/// This will also check for errors in the CRT computation.
-#[inline]
-pub fn decrypt_and_check<R: Rng>(
-    rng: Option<&mut R>,
-    priv_key: &RSAPrivateKey,
-    c: &BigUint,
-) -> Result<BigUint> {
-    let m = decrypt(rng, priv_key, c)?;
-
-    // In order to defend against errors in the CRT computation, m^e is
-    // calculated, which should match the original ciphertext.
-    let check = encrypt(priv_key, &m);
-    if c != &check {
-        return Err(Error::Internal);
-    }
-
-    Ok(m)
-}
-
-/// Returns a new vector of the given length, with 0s left padded.
-#[inline]
-pub fn left_pad(input: &[u8], size: usize) -> Vec<u8> {
-    let n = if input.len() > size {
-        size
-    } else {
-        input.len()
-    };
-
-    let mut out = vec![0u8; size];
-    out[size - n..].copy_from_slice(input);
-    out
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use internals;
     use num_traits::{FromPrimitive, ToPrimitive};
     use rand::{thread_rng, ThreadRng};
 
@@ -630,13 +474,13 @@ mod tests {
 
         let pub_key: RSAPublicKey = private_key.clone().into();
         let m = BigUint::from_u64(42).expect("invalid 42");
-        let c = encrypt(&pub_key, &m);
-        let m2 = decrypt::<ThreadRng>(None, &private_key, &c)
+        let c = internals::encrypt(&pub_key, &m);
+        let m2 = internals::decrypt::<ThreadRng>(None, &private_key, &c)
             .expect("unable to decrypt without blinding");
         assert_eq!(m, m2);
         let mut rng = thread_rng();
-        let m3 =
-            decrypt(Some(&mut rng), &private_key, &c).expect("unable to decrypt with blinding");
+        let m3 = internals::decrypt(Some(&mut rng), &private_key, &c)
+            .expect("unable to decrypt with blinding");
         assert_eq!(m, m3);
     }
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -426,6 +426,21 @@ impl RSAPrivateKey {
             _ => Err(Error::InvalidPaddingScheme),
         }
     }
+
+    /// Blind the given digest, returning the blinded digest and the unblinding factor.
+    pub fn blind<R: Rng>(&self, rng: &mut R, digest: &[u8]) -> (Vec<u8>, Vec<u8>) {
+        let c = BigUint::from_bytes_be(digest);
+        let (c, unblinder) = blind::<R>(rng, self, &c);
+        (c.to_bytes_be(), unblinder.to_bytes_be())
+    }
+
+    /// Unblind the given signature, producing a signature that also signs the unblided digest.
+    pub fn unblind(&self, blinded_sig: &[u8], unblinder: &[u8]) -> Vec<u8> {
+        let blinded_sig = BigUint::from_bytes_be(blinded_sig);
+        let unblinder = BigUint::from_bytes_be(unblinder);
+        let unblinded = unblind(self, &blinded_sig, &unblinder);
+        unblinded.to_bytes_be()
+    }
 }
 
 #[inline]
@@ -446,7 +461,7 @@ pub fn encrypt<K: PublicKey>(key: &K, m: &BigUint) -> BigUint {
     m.modpow(key.e(), key.n())
 }
 
-// Returns the blinded c, along with the unblinding factor.
+// Returns the bed c, along with the unblinding factor.
 pub fn blind<R: Rng>(rng: &mut R, priv_key: &RSAPrivateKey, c: &BigUint) -> (BigUint, BigUint) {
     // Blinding involves multiplying c by r^e.
     // Then the decryption operation performs (m^e * r^e)^d mod n
@@ -478,8 +493,8 @@ pub fn blind<R: Rng>(rng: &mut R, priv_key: &RSAPrivateKey, c: &BigUint) -> (Big
 }
 
 // Given an m and and unblinding factor, unblind the m.
-pub fn unblind(priv_key: &RSAPrivateKey, m: &BigUint, unblind: &BigUint) -> BigUint {
-    (m * unblind) % priv_key.n()
+pub fn unblind(priv_key: &RSAPrivateKey, m: &BigUint, unblinder: &BigUint) -> BigUint {
+    (m * unblinder) % priv_key.n()
 }
 
 /// Performs RSA decryption, resulting in a plaintext `BigUint`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,10 +51,22 @@ extern crate serde_test;
 #[cfg(test)]
 extern crate sha1;
 
+/// useful algorithms
 pub mod algorithms;
+
+/// Contains raw RSA functions that should not be used directly.
+///
+/// This module is provided so that other crates that implement non-standard RSA schemes can use these RSA primitives.
+/// If you are not implementing a custom RSA-based scheme, you should not use these functions.
 pub mod danger;
+
+/// Errot types
 pub mod errors;
+
+/// Supported hash functions.
 pub mod hash;
+
+/// Supported padding schemes.
 pub mod padding;
 
 mod key;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,12 +54,6 @@ extern crate sha1;
 /// Useful algorithms.
 pub mod algorithms;
 
-/// Contains raw RSA functions that should not be used directly.
-///
-/// This module is provided so that other crates that implement non-standard RSA schemes can use these RSA primitives.
-/// If you are not implementing a custom RSA-based scheme, you should not use these functions.
-pub mod danger;
-
 /// Error types.
 pub mod errors;
 
@@ -74,3 +68,12 @@ mod pkcs1v15;
 
 pub use self::key::{PublicKey, RSAPrivateKey, RSAPublicKey};
 pub use self::padding::PaddingScheme;
+
+// Optionally expose internals if requested via feature-flag.
+
+#[cfg(not(feature = "expose-internals"))]
+mod internals;
+
+/// Internal raw RSA functions.
+#[cfg(feature = "expose-internals")]
+pub mod internals;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ extern crate serde_test;
 #[cfg(test)]
 extern crate sha1;
 
-/// useful algorithms
+/// Useful algorithms.
 pub mod algorithms;
 
 /// Contains raw RSA functions that should not be used directly.
@@ -60,7 +60,7 @@ pub mod algorithms;
 /// If you are not implementing a custom RSA-based scheme, you should not use these functions.
 pub mod danger;
 
-/// Errot types
+/// Error types.
 pub mod errors;
 
 /// Supported hash functions.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ extern crate serde_test;
 extern crate sha1;
 
 pub mod algorithms;
+pub mod danger;
 pub mod errors;
 pub mod hash;
 pub mod padding;


### PR DESCRIPTION
I've split blinding and unblinding into their own public functions.   

This relates to #9 - instead of implementing a full blind-signing protocol in this crate, we just expose the `blind` and `unblind` functions to make building such a protocol easier. 

In addition I've re-exported the raw RSA functions into a new module called 'danger'.   The intention here is to allow other crates that are creating custom RSA schemes to access raw RSA functions, but to ward off casual users. 