### PR TITLE
adds the to_public_key() method for RSAPrivateKey

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -286,7 +286,7 @@ impl RSAPrivateKey {
     ///
     /// Generally this is not needed since `RSAPrivateKey` implements the `PublicKey` trait,
     /// but it can occationally be useful to discard the private information entirely.
-    pub fn to_public(&self) -> RSAPublicKey {
+    pub fn to_public_key(&self) -> RSAPublicKey {
         // Safe to unwrap since n and e are already verified.
         RSAPublicKey::new(self.n().clone(), self.e().clone()).unwrap()
     }

--- a/src/key.rs
+++ b/src/key.rs
@@ -282,11 +282,11 @@ impl RSAPrivateKey {
         k
     }
 
-    /// Extract the public key from the private key, cloning `n` and `e`.
+    /// Get the public key from the private key, cloning `n` and `e`.
     ///
     /// Generally this is not needed since `RSAPrivateKey` implements the `PublicKey` trait,
     /// but it can occationally be useful to discard the private information entirely.
-    pub fn extract_public(&self) -> RSAPublicKey {
+    pub fn to_public(&self) -> RSAPublicKey {
         // Safe to unwrap since n and e are already verified.
         RSAPublicKey::new(self.n().clone(), self.e().clone()).unwrap()
     }

--- a/src/key.rs
+++ b/src/key.rs
@@ -282,6 +282,15 @@ impl RSAPrivateKey {
         k
     }
 
+    /// Extract the public key from the private key, cloning `n` and `e`.
+    ///
+    /// Generally this is not needed since `RSAPrivateKey` implements the `PublicKey` trait,
+    /// but it can occationally be useful to discard the private information entirely.
+    pub fn extract_public(&self) -> RSAPublicKey {
+        // Safe to unwrap since n and e are already verified.
+        RSAPublicKey::new(self.n().clone(), self.e().clone()).unwrap()
+    }
+
     /// Performs some calculations to speed up private key operations.
     pub fn precompute(&mut self) {
         if self.precomputed.is_some() {


### PR DESCRIPTION
While generally passing around RSAPrivateKey as a `PublicKey` trait is optimal, there are some instances where you want to deal in concrete types and not be passing around the secret private data.  This PR adds a utility `extract_public()` method for RSAPrivateKey for those circumstances. 
