### PR TITLE
Moving to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rsa"
 version = "0.1.3-alpha.0"
 authors = ["RustCrypto Developers", "dignifiedquire <dignifiedquire@gmail.com>"]
+edition = "2018"
 description = "Pure Rust RSA implementation"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/rsa"

--- a/benches/key.rs
+++ b/benches/key.rs
@@ -1,22 +1,16 @@
 #![feature(test)]
 
-use base64;
-
-
-
-
-
 extern crate test;
 
+use base64;
 use num_bigint::BigUint;
 use num_traits::{FromPrimitive, Num};
 use rand::{SeedableRng, StdRng};
-use sha2::{Digest, Sha256};
-use test::Bencher;
-
 use rsa::hash::Hashes;
 use rsa::padding::PaddingScheme;
 use rsa::RSAPrivateKey;
+use sha2::{Digest, Sha256};
+use test::Bencher;
 
 const DECRYPT_VAL: &'static str =
     "XW4qfrpQDarEMBfPyIYE9UvuOFkbBi0tiGYbIOJPLMNe/LWuPD0BQ7ceqlOlPPcKLinYz0DlnqW3It/V7ae59zw9afA3YIWdq0Ut2BnYL+aJixnqaP+PjsQNcHg6axCF11iNQ4jpXrZDiQcI+q9EEzZDTMsiMxtjfgBQUd8LHT87YoQXDWaFPCVpliACMc8aUk442kH1tc4jEuXwjEjFErvAM/J7VizCdU/dnKrlq2mBDzvZ6hxY9TYHFB/zY6DZPJAgEMUxYWCR9xPJ7X256DV1Kt0Ht33DWoFcgh/pPLM1q9pK0HVxCdclXfZOeCqlrLgZ5Gxv5DM4BtV7Z4m85w==";

--- a/benches/key.rs
+++ b/benches/key.rs
@@ -1,11 +1,11 @@
 #![feature(test)]
 
-extern crate base64;
-extern crate num_bigint;
-extern crate num_traits;
-extern crate rand;
-extern crate rsa;
-extern crate sha2;
+use base64;
+
+
+
+
+
 extern crate test;
 
 use num_bigint::BigUint;

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -3,8 +3,8 @@ use num_bigint::{BigUint, RandPrime};
 use num_traits::{FromPrimitive, One, Zero};
 use rand::Rng;
 
-use errors::{Error, Result};
-use key::RSAPrivateKey;
+use crate::errors::{Error, Result};
+use crate::key::RSAPrivateKey;
 
 /// Default exponent for RSA keys.
 const EXP: u64 = 65537;

--- a/src/internals.rs
+++ b/src/internals.rs
@@ -1,5 +1,5 @@
-use errors::{Error, Result};
-use key::{PublicKey, RSAPrivateKey};
+use crate::errors::{Error, Result};
+use crate::key::{PublicKey, RSAPrivateKey};
 use num_bigint::{BigInt, BigUint, ModInverse, RandBigInt, Sign::Plus};
 use num_traits::{One, Signed, Zero};
 use rand::Rng;

--- a/src/internals.rs
+++ b/src/internals.rs
@@ -7,87 +7,87 @@ use rand::Rng;
 /// Raw RSA encryption of m with the public key. No padding is performed.
 #[inline]
 pub fn encrypt<K: PublicKey>(key: &K, m: &BigUint) -> BigUint {
-  m.modpow(key.e(), key.n())
+    m.modpow(key.e(), key.n())
 }
 
 /// Performs raw RSA decryption with no padding, resulting in a plaintext `BigUint`.
 /// Peforms RSA blinding if an `Rng` is passed.
 #[inline]
 pub fn decrypt<R: Rng>(
-  mut rng: Option<&mut R>,
-  priv_key: &RSAPrivateKey,
-  c: &BigUint,
+    mut rng: Option<&mut R>,
+    priv_key: &RSAPrivateKey,
+    c: &BigUint,
 ) -> Result<BigUint> {
-  if c >= priv_key.n() {
-    return Err(Error::Decryption);
-  }
+    if c >= priv_key.n() {
+        return Err(Error::Decryption);
+    }
 
-  if priv_key.n().is_zero() {
-    return Err(Error::Decryption);
-  }
+    if priv_key.n().is_zero() {
+        return Err(Error::Decryption);
+    }
 
-  let mut ir = None;
-  let c = if let Some(ref mut rng) = rng {
-    let (blinded, unblinder) = blind(rng, priv_key, c);
-    ir = Some(unblinder);
-    blinded
-  } else {
-    c.clone()
-  };
+    let mut ir = None;
+    let c = if let Some(ref mut rng) = rng {
+        let (blinded, unblinder) = blind(rng, priv_key, c);
+        ir = Some(unblinder);
+        blinded
+    } else {
+        c.clone()
+    };
 
-  let m = match priv_key.precomputed {
-    None => c.modpow(priv_key.d(), priv_key.n()),
-    Some(ref precomputed) => {
-      // We have the precalculated values needed for the CRT.
+    let m = match priv_key.precomputed {
+        None => c.modpow(priv_key.d(), priv_key.n()),
+        Some(ref precomputed) => {
+            // We have the precalculated values needed for the CRT.
 
-      let p = &priv_key.primes()[0];
-      let q = &priv_key.primes()[1];
+            let p = &priv_key.primes()[0];
+            let q = &priv_key.primes()[1];
 
-      let mut m = BigInt::from_biguint(Plus, c.modpow(&precomputed.dp, p));
-      let mut m2 = BigInt::from_biguint(Plus, c.modpow(&precomputed.dq, q));
+            let mut m = BigInt::from_biguint(Plus, c.modpow(&precomputed.dp, p));
+            let mut m2 = BigInt::from_biguint(Plus, c.modpow(&precomputed.dq, q));
 
-      m -= &m2;
+            m -= &m2;
 
-      // clones make me sad :(
-      let primes: Vec<_> = priv_key
-        .primes()
-        .iter()
-        .map(|v| BigInt::from_biguint(Plus, v.clone()))
-        .collect();
+            // clones make me sad :(
+            let primes: Vec<_> = priv_key
+                .primes()
+                .iter()
+                .map(|v| BigInt::from_biguint(Plus, v.clone()))
+                .collect();
 
-      while m.is_negative() {
-        m += &primes[0];
-      }
-      m *= &precomputed.qinv;
-      m %= &primes[0];
-      m *= &primes[1];
-      m += m2;
+            while m.is_negative() {
+                m += &primes[0];
+            }
+            m *= &precomputed.qinv;
+            m %= &primes[0];
+            m *= &primes[1];
+            m += m2;
 
-      let c = BigInt::from_biguint(Plus, c);
-      for (i, value) in precomputed.crt_values.iter().enumerate() {
-        let prime = &primes[2 + i];
-        m2 = c.modpow(&value.exp, prime);
-        m2 -= &m;
-        m2 *= &value.coeff;
-        m2 %= prime;
-        while m2.is_negative() {
-          m2 += prime;
+            let c = BigInt::from_biguint(Plus, c);
+            for (i, value) in precomputed.crt_values.iter().enumerate() {
+                let prime = &primes[2 + i];
+                m2 = c.modpow(&value.exp, prime);
+                m2 -= &m;
+                m2 *= &value.coeff;
+                m2 %= prime;
+                while m2.is_negative() {
+                    m2 += prime;
+                }
+                m2 *= &value.r;
+                m += &m2;
+            }
+
+            m.to_biguint().expect("failed to decrypt")
         }
-        m2 *= &value.r;
-        m += &m2;
-      }
+    };
 
-      m.to_biguint().expect("failed to decrypt")
+    match ir {
+        Some(ref ir) => {
+            // unblind
+            Ok(unblind(priv_key, &m, &ir))
+        }
+        None => Ok(m),
     }
-  };
-
-  match ir {
-    Some(ref ir) => {
-      // unblind
-      Ok(unblind(priv_key, &m, &ir))
-    }
-    None => Ok(m),
-  }
 }
 
 /// Performs RSA decryption, resulting in a plaintext `BigUint`.
@@ -95,68 +95,68 @@ pub fn decrypt<R: Rng>(
 /// This will also check for errors in the CRT computation.
 #[inline]
 pub fn decrypt_and_check<R: Rng>(
-  rng: Option<&mut R>,
-  priv_key: &RSAPrivateKey,
-  c: &BigUint,
+    rng: Option<&mut R>,
+    priv_key: &RSAPrivateKey,
+    c: &BigUint,
 ) -> Result<BigUint> {
-  let m = decrypt(rng, priv_key, c)?;
+    let m = decrypt(rng, priv_key, c)?;
 
-  // In order to defend against errors in the CRT computation, m^e is
-  // calculated, which should match the original ciphertext.
-  let check = encrypt(priv_key, &m);
-  if c != &check {
-    return Err(Error::Internal);
-  }
+    // In order to defend against errors in the CRT computation, m^e is
+    // calculated, which should match the original ciphertext.
+    let check = encrypt(priv_key, &m);
+    if c != &check {
+        return Err(Error::Internal);
+    }
 
-  Ok(m)
+    Ok(m)
 }
 
 /// Returns the blinded c, along with the unblinding factor.
 pub fn blind<R: Rng, K: PublicKey>(rng: &mut R, key: &K, c: &BigUint) -> (BigUint, BigUint) {
-  // Blinding involves multiplying c by r^e.
-  // Then the decryption operation performs (m^e * r^e)^d mod n
-  // which equals mr mod n. The factor of r can then be removed
-  // by multiplying by the multiplicative inverse of r.
+    // Blinding involves multiplying c by r^e.
+    // Then the decryption operation performs (m^e * r^e)^d mod n
+    // which equals mr mod n. The factor of r can then be removed
+    // by multiplying by the multiplicative inverse of r.
 
-  let mut r: BigUint;
-  let mut ir: Option<BigInt>;
-  let unblinder;
-  loop {
-    r = rng.gen_biguint_below(key.n());
-    if r.is_zero() {
-      r = BigUint::one();
+    let mut r: BigUint;
+    let mut ir: Option<BigInt>;
+    let unblinder;
+    loop {
+        r = rng.gen_biguint_below(key.n());
+        if r.is_zero() {
+            r = BigUint::one();
+        }
+        ir = r.clone().mod_inverse(key.n());
+        if let Some(ir) = ir {
+            if let Some(ub) = ir.to_biguint() {
+                unblinder = ub;
+                break;
+            }
+        }
     }
-    ir = r.clone().mod_inverse(key.n());
-    if let Some(ir) = ir {
-      if let Some(ub) = ir.to_biguint() {
-        unblinder = ub;
-        break;
-      }
-    }
-  }
 
-  let e = key.e();
-  let rpowe = r.modpow(&e, key.n()); // N != 0
-  let c = (c * &rpowe) % key.n();
+    let e = key.e();
+    let rpowe = r.modpow(&e, key.n()); // N != 0
+    let c = (c * &rpowe) % key.n();
 
-  (c, unblinder)
+    (c, unblinder)
 }
 
 /// Given an m and and unblinding factor, unblind the m.
 pub fn unblind(key: impl PublicKey, m: &BigUint, unblinder: &BigUint) -> BigUint {
-  (m * unblinder) % key.n()
+    (m * unblinder) % key.n()
 }
 
 /// Returns a new vector of the given length, with 0s left padded.
 #[inline]
 pub fn left_pad(input: &[u8], size: usize) -> Vec<u8> {
-  let n = if input.len() > size {
-    size
-  } else {
-    input.len()
-  };
+    let n = if input.len() > size {
+        size
+    } else {
+        input.len()
+    };
 
-  let mut out = vec![0u8; size];
-  out[size - n..].copy_from_slice(input);
-  out
+    let mut out = vec![0u8; size];
+    out[size - n..].copy_from_slice(input);
+    out
 }

--- a/src/key.rs
+++ b/src/key.rs
@@ -7,11 +7,11 @@ use rand::{Rng, ThreadRng};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
-use algorithms::generate_multi_prime_key;
-use errors::{Error, Result};
-use hash::Hash;
-use padding::PaddingScheme;
-use pkcs1v15;
+use crate::algorithms::generate_multi_prime_key;
+use crate::errors::{Error, Result};
+use crate::hash::Hash;
+use crate::padding::PaddingScheme;
+use crate::pkcs1v15;
 
 lazy_static! {
     static ref MIN_PUB_EXPONENT: BigUint = BigUint::from_u64(2).unwrap();
@@ -445,7 +445,7 @@ pub fn check_public(public_key: &impl PublicKey) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use internals;
+    use crate::internals;
     use num_traits::{FromPrimitive, ToPrimitive};
     use rand::{thread_rng, ThreadRng};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,18 +26,11 @@
 //! ```
 //!
 
-
-
-
 #[macro_use]
 extern crate lazy_static;
 
 #[macro_use]
 extern crate failure;
-
-
-
-
 
 #[cfg(feature = "serde1")]
 extern crate serde;
@@ -48,7 +41,6 @@ extern crate base64;
 extern crate hex;
 #[cfg(all(test, feature = "serde1"))]
 extern crate serde_test;
-
 
 /// Useful algorithms.
 pub mod algorithms;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,18 +26,18 @@
 //! ```
 //!
 
-extern crate num_bigint;
-extern crate num_integer;
-extern crate num_traits;
+
+
+
 #[macro_use]
 extern crate lazy_static;
-extern crate byteorder;
+
 #[macro_use]
 extern crate failure;
-extern crate clear_on_drop;
-extern crate num_iter;
-extern crate rand;
-extern crate subtle;
+
+
+
+
 
 #[cfg(feature = "serde1")]
 extern crate serde;
@@ -48,8 +48,7 @@ extern crate base64;
 extern crate hex;
 #[cfg(all(test, feature = "serde1"))]
 extern crate serde_test;
-#[cfg(test)]
-extern crate sha1;
+
 
 /// Useful algorithms.
 pub mod algorithms;

--- a/src/pkcs1v15.rs
+++ b/src/pkcs1v15.rs
@@ -2,10 +2,10 @@ use num_bigint::BigUint;
 use rand::Rng;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
-use errors::{Error, Result};
-use hash::Hash;
-use internals;
-use key::{self, PublicKey, RSAPrivateKey};
+use crate::errors::{Error, Result};
+use crate::hash::Hash;
+use crate::internals;
+use crate::key::{self, PublicKey, RSAPrivateKey};
 
 // Encrypts the given message with RSA and the padding
 // scheme from PKCS#1 v1.5.  The message must be no longer than the
@@ -243,9 +243,9 @@ mod tests {
     use rand::thread_rng;
     use sha1::{Digest, Sha1};
 
-    use hash::Hashes;
-    use key::RSAPublicKey;
-    use padding::PaddingScheme;
+    use crate::hash::Hashes;
+    use crate::key::RSAPublicKey;
+    use crate::padding::PaddingScheme;
 
     #[test]
     fn test_non_zero_bytes() {


### PR DESCRIPTION
This pull request does two things:

1. Moves to the 2018 edition and applies 2018 edition idioms
2. Runs rustfmt

The application of rustfmt makes this PR look scarier than it is, so you may want to checkout 558d34f, review the diff at 558d34f, and then and run rustfmt yourself. 