### PR TITLE
Reexport biguint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,8 @@ extern crate hex;
 #[cfg(all(test, feature = "serde1"))]
 extern crate serde_test;
 
+pub use num_bigint::BigUint;
+
 /// Useful algorithms.
 pub mod algorithms;
 


### PR DESCRIPTION
BigUint is part of the public API surface of RSA. As such, I think it's a good idea to reexport it. It avoids forcing the user to add a dependency on num-bigint-dig when importing pubkeys or privkeys.