### PR TITLE
Initial key trait refactor

### DIFF
--- a/src/internals.rs
+++ b/src/internals.rs
@@ -5,11 +5,11 @@ use std::borrow::Cow;
 use zeroize::Zeroize;
 
 use crate::errors::{Error, Result};
-use crate::key::{PublicKey, RSAPrivateKey};
+use crate::key::{PublicKeyParts, RSAPrivateKey};
 
 /// Raw RSA encryption of m with the public key. No padding is performed.
 #[inline]
-pub fn encrypt<K: PublicKey>(key: &K, m: &BigUint) -> BigUint {
+pub fn encrypt<K: PublicKeyParts>(key: &K, m: &BigUint) -> BigUint {
     m.modpow(key.e(), key.n())
 }
 
@@ -125,7 +125,7 @@ pub fn decrypt_and_check<R: Rng>(
 }
 
 /// Returns the blinded c, along with the unblinding factor.
-pub fn blind<R: Rng, K: PublicKey>(rng: &mut R, key: &K, c: &BigUint) -> (BigUint, BigUint) {
+pub fn blind<R: Rng, K: PublicKeyParts>(rng: &mut R, key: &K, c: &BigUint) -> (BigUint, BigUint) {
     // Blinding involves multiplying c by r^e.
     // Then the decryption operation performs (m^e * r^e)^d mod n
     // which equals mr mod n. The factor of r can then be removed
@@ -162,7 +162,7 @@ pub fn blind<R: Rng, K: PublicKey>(rng: &mut R, key: &K, c: &BigUint) -> (BigUin
 }
 
 /// Given an m and and unblinding factor, unblind the m.
-pub fn unblind(key: impl PublicKey, m: &BigUint, unblinder: &BigUint) -> BigUint {
+pub fn unblind(key: impl PublicKeyParts, m: &BigUint, unblinder: &BigUint) -> BigUint {
     (m * unblinder) % key.n()
 }
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -12,6 +12,7 @@ use crate::errors::{Error, Result};
 use crate::hash::Hash;
 use crate::padding::PaddingScheme;
 use crate::pkcs1v15;
+use crate::raw::EncryptionPrimitive;
 
 lazy_static! {
     static ref MIN_PUB_EXPONENT: BigUint = BigUint::from_u64(2).unwrap();
@@ -126,7 +127,7 @@ impl From<RSAPrivateKey> for RSAPublicKey {
 }
 
 /// Generic trait for operations on a public key.
-pub trait PublicKey {
+pub trait PublicKey: EncryptionPrimitive {
     /// Returns the modulus of the key.
     fn n(&self) -> &BigUint;
     /// Returns the public exponent of the key.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@ pub mod padding;
 
 mod key;
 mod pkcs1v15;
+mod raw;
 
 pub use self::key::{PublicKey, RSAPrivateKey, RSAPublicKey};
 pub use self::padding::PaddingScheme;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,20 +8,21 @@
 //! extern crate rsa;
 //! extern crate rand;
 //!
-//! use rsa::{PublicKey, RSAPrivateKey, PaddingScheme};
+//! use rsa::{PublicKey, RSAPrivateKey, RSAPublicKey, PaddingScheme};
 //! use rand::rngs::OsRng;
 //!
 //! let mut rng = OsRng;
 //! let bits = 2048;
-//! let key = RSAPrivateKey::new(&mut rng, bits).expect("failed to generate a key");
+//! let private_key = RSAPrivateKey::new(&mut rng, bits).expect("failed to generate a key");
+//! let public_key = RSAPublicKey::from(private_key.clone());
 //!
 //! // Encrypt
 //! let data = b"hello world";
-//! let enc_data = key.encrypt(&mut rng, PaddingScheme::PKCS1v15, &data[..]).expect("failed to encrypt");
+//! let enc_data = public_key.encrypt(&mut rng, PaddingScheme::PKCS1v15, &data[..]).expect("failed to encrypt");
 //! assert_ne!(&data[..], &enc_data[..]);
 //!
 //! // Decrypt
-//! let dec_data = key.decrypt(PaddingScheme::PKCS1v15, &enc_data).expect("failed to decrypt");
+//! let dec_data = private_key.decrypt(PaddingScheme::PKCS1v15, &enc_data).expect("failed to decrypt");
 //! assert_eq!(&data[..], &dec_data[..]);
 //! ```
 //!

--- a/src/pkcs1v15.rs
+++ b/src/pkcs1v15.rs
@@ -3,7 +3,7 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 use crate::errors::{Error, Result};
 use crate::hash::Hash;
-use crate::key::{self, PublicKey, RSAPrivateKey};
+use crate::key::{self, PublicKey, PublicKeyParts, RSAPrivateKey};
 use crate::raw::DecryptionPrimitive;
 
 // Encrypts the given message with RSA and the padding

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1,0 +1,85 @@
+use num_bigint::BigUint;
+use rand::Rng;
+use zeroize::Zeroize;
+
+use crate::errors::Result;
+use crate::internals;
+use crate::key::{PublicKey, RSAPrivateKey, RSAPublicKey};
+
+pub trait EncryptionPrimitive {
+    /// Do NOT use directly! Only for implementors.
+    fn raw_encryption_primitive(&self, plaintext: &[u8]) -> Result<Vec<u8>>;
+}
+
+pub trait DecryptionPrimitive {
+    /// Do NOT use directly! Only for implementors.
+    fn raw_decryption_primitive<R: Rng>(
+        &self,
+        rng: Option<&mut R>,
+        ciphertext: &[u8],
+    ) -> Result<Vec<u8>>;
+}
+
+impl EncryptionPrimitive for RSAPublicKey {
+    fn raw_encryption_primitive(&self, plaintext: &[u8]) -> Result<Vec<u8>> {
+        let mut m = BigUint::from_bytes_be(plaintext);
+        let mut c = internals::encrypt(self, &m);
+        let mut c_bytes = c.to_bytes_be();
+        let ciphertext = internals::left_pad(&c_bytes, self.size());
+
+        // clear out tmp values
+        m.zeroize();
+        c.zeroize();
+        c_bytes.zeroize();
+
+        Ok(ciphertext)
+    }
+}
+
+impl<'a> EncryptionPrimitive for &'a RSAPublicKey {
+    fn raw_encryption_primitive(&self, plaintext: &[u8]) -> Result<Vec<u8>> {
+        (*self).raw_encryption_primitive(plaintext)
+    }
+}
+
+impl EncryptionPrimitive for RSAPrivateKey {
+    fn raw_encryption_primitive(&self, plaintext: &[u8]) -> Result<Vec<u8>> {
+        let mut m = BigUint::from_bytes_be(plaintext);
+        let mut c = internals::encrypt(self, &m);
+        let mut c_bytes = c.to_bytes_be();
+        let ciphertext = internals::left_pad(&c_bytes, self.size());
+
+        // clear out tmp values
+        m.zeroize();
+        c.zeroize();
+        c_bytes.zeroize();
+
+        Ok(ciphertext)
+    }
+}
+
+impl<'a> EncryptionPrimitive for &'a RSAPrivateKey {
+    fn raw_encryption_primitive(&self, plaintext: &[u8]) -> Result<Vec<u8>> {
+        (*self).raw_encryption_primitive(plaintext)
+    }
+}
+
+impl DecryptionPrimitive for RSAPrivateKey {
+    fn raw_decryption_primitive<R: Rng>(
+        &self,
+        rng: Option<&mut R>,
+        ciphertext: &[u8],
+    ) -> Result<Vec<u8>> {
+        let mut c = BigUint::from_bytes_be(ciphertext);
+        let mut m = internals::decrypt_and_check(rng, self, &c)?;
+        let mut m_bytes = m.to_bytes_be();
+        let plaintext = internals::left_pad(&m_bytes, self.size());
+
+        // clear tmp values
+        c.zeroize();
+        m.zeroize();
+        m_bytes.zeroize();
+
+        Ok(plaintext)
+    }
+}


### PR DESCRIPTION
This is part of #32, and a precursor for #34.

The new trait structure:
- `PublicKeyParts` - provides access to the modulus, exponent, and size.
- `EncryptionPrimitive` - raw RSA encryption, for implementers.
- `DecryptionPrimitive` - raw RSA decryption, for implementers.
- `PublicKey: EncryptionPrimitive + PublicKeyParts` - the public key API for users. Home to `encrypt` and `verify` functions.
- `PrivateKey: DecryptionPrimitive + PublicKeyParts` - the private key API for users. Will eventually be home to `decrypt` and `sign` functions.