### PR TITLE
pkcs1v15: Make decrypt() and sign() generic over PrivateKey

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -544,7 +544,7 @@ impl RSAPrivateKey {
     pub fn decrypt(&self, padding: PaddingScheme, ciphertext: &[u8]) -> Result<Vec<u8>> {
         match padding {
             // need to pass any Rng as the type arg, so the type checker is happy, it is not actually used for anything
-            PaddingScheme::PKCS1v15 => pkcs1v15::decrypt::<ThreadRng>(None, self, ciphertext),
+            PaddingScheme::PKCS1v15 => pkcs1v15::decrypt::<ThreadRng, _>(None, self, ciphertext),
             PaddingScheme::OAEP => unimplemented!("not yet implemented"),
             _ => Err(Error::InvalidPaddingScheme),
         }
@@ -573,7 +573,7 @@ impl RSAPrivateKey {
         digest: &[u8],
     ) -> Result<Vec<u8>> {
         match padding {
-            PaddingScheme::PKCS1v15 => pkcs1v15::sign::<ThreadRng, _>(None, self, hash, digest),
+            PaddingScheme::PKCS1v15 => pkcs1v15::sign::<ThreadRng, _, _>(None, self, hash, digest),
             PaddingScheme::PSS => unimplemented!("not yet implemented"),
             _ => Err(Error::InvalidPaddingScheme),
         }


### PR DESCRIPTION
A small refactor so that public and private keys are both generic inside the PKCS1v15 implementation.

Part of #34.