### PR TITLE
feat: allow for custom public exponent value in keygen

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -8,7 +8,7 @@ use serde_crate::{Deserialize, Serialize};
 use std::ops::Deref;
 use zeroize::Zeroize;
 
-use crate::algorithms::generate_multi_prime_key;
+use crate::algorithms::{generate_multi_prime_key, generate_multi_prime_key_with_exp};
 use crate::errors::{Error, Result};
 
 use crate::padding::PaddingScheme;
@@ -336,6 +336,18 @@ impl RSAPrivateKey {
     /// Generate a new RSA key pair of the given bit size using the passed in `rng`.
     pub fn new<R: Rng>(rng: &mut R, bit_size: usize) -> Result<RSAPrivateKey> {
         generate_multi_prime_key(rng, 2, bit_size)
+    }
+
+    /// Generate a new RSA key pair of the given bit size and the public exponent
+    /// using the passed in `rng`.
+    ///
+    /// Unless you have specific needs, you should use `RSAPrivateKey::new` instead.
+    pub fn new_with_exp<R: Rng>(
+        rng: &mut R,
+        bit_size: usize,
+        exp: &BigUint,
+    ) -> Result<RSAPrivateKey> {
+        generate_multi_prime_key_with_exp(rng, 2, bit_size, exp)
     }
 
     /// Constructs an RSA key pair from the individual components.


### PR DESCRIPTION
This commit adds a function to `rsa::algorithms` called `generate_multi_prime_key_with_exp` which allows the caller to specify a custom value for the public key exponent.

This commit also adds a convenience routine to `rsa::RSAPrivateKey` called `new_with_exp` which allows the caller to specify the custom value for the public key exponent as part of `rsa::RSAPrivateKey` constructor.

Exposing the public key exponent matches an OpenSSL call `openssl::rsa::generate_with_e` which is useful in certain settings such when generating the signing keys for SGX enclaves.

Lemme know what y'all think about this change! Oh, and if you feel the PR could be improved upon or some bits are missing, lemme know and I'll be happy to iterate through with you until we get something that's mergeable!