### PR TITLE
feat: improve OpenSSL compatibility for encoding and decoding keys

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -17,6 +17,9 @@ const DEFAULT_ENCODING_CONFIG: EncodeConfig = EncodeConfig {
 };
 
 #[cfg(feature = "pem")]
+/// Trait for encoding the private key in the PEM format
+/// 
+/// Important: Encoding multi prime keys isn't supported. See [RustCrypto/RSA#66](https://github.com/RustCrypto/RSA/issues/66) for more info
 pub trait PrivateKeyPemEncoding: PrivateKeyEncoding {
     const PKCS1_HEADER: &'static str;
     const PKCS8_HEADER: &'static str = "PRIVATE KEY";
@@ -25,8 +28,6 @@ pub trait PrivateKeyPemEncoding: PrivateKeyEncoding {
     ///
     /// Encodes the key with the header:
     /// `-----BEGIN <name> PRIVATE KEY-----`
-    ///
-    /// Important: Encoding multi prime keys isn't supported. See [RustCrypto/RSA#66](https://github.com/RustCrypto/RSA/issues/66) for more info 
     ///
     /// # Example
     ///
@@ -45,8 +46,6 @@ pub trait PrivateKeyPemEncoding: PrivateKeyEncoding {
     }
 
     /// Converts a Private key into `PKCS1` encoded bytes in pem format with encoding config.
-    ///
-    /// Important: Encoding multi prime keys isn't supported. See [RustCrypto/RSA#66](https://github.com/RustCrypto/RSA/issues/66) for more info 
     ///
     /// # Example
     /// ```
@@ -74,8 +73,6 @@ pub trait PrivateKeyPemEncoding: PrivateKeyEncoding {
     /// Encodes the key with the header:
     /// `-----BEGIN PRIVATE KEY-----`
     ///
-    /// Important: Encoding multi prime keys isn't supported. See [RustCrypto/RSA#66](https://github.com/RustCrypto/RSA/issues/66) for more info 
-    ///
     /// # Example
     ///
     /// ```
@@ -93,8 +90,6 @@ pub trait PrivateKeyPemEncoding: PrivateKeyEncoding {
     }
 
     /// Converts a Private key into `PKCS8` encoded bytes in pem format with encoding config.
-    ///
-    /// Important: Encoding multi prime keys isn't supported. See [RustCrypto/RSA#66](https://github.com/RustCrypto/RSA/issues/66) for more info 
     ///
     /// # Example
     /// ```
@@ -231,15 +226,16 @@ fn to_bigint(value: &crate::BigUint) -> simple_asn1::BigInt {
     simple_asn1::BigInt::from_signed_bytes_le(&value.to_bigint().unwrap().to_signed_bytes_le())
 }
 
+/// Trait for encoding the private key in the PKCS#1/PKCS#8 format
+/// 
+/// Important: Encoding multi prime keys isn't supported. See [RustCrypto/RSA#66](https://github.com/RustCrypto/RSA/issues/66) for more info
 pub trait PrivateKeyEncoding {
     /// Encodes a Private key to into `PKCS1` bytes.
     ///
     /// This data will be `base64` encoded which would be used
     /// following a `-----BEGIN <name> PRIVATE KEY-----` header.
     ///
-    /// <https://tls.mbed.org/kb/cryptography/asn1-key-structures-in-der-and-pem>
-    ///
-    /// Important: Encoding multi prime keys isn't supported. See [RustCrypto/RSA#66](https://github.com/RustCrypto/RSA/issues/66) for more info 
+    /// <https://tls.mbed.org/kb/cryptography/asn1-key-structures-in-der-and-pem> 
     fn to_pkcs1(&self) -> Result<Vec<u8>>;
 
     /// Encodes a Private key to into `PKCS8` bytes.
@@ -248,8 +244,6 @@ pub trait PrivateKeyEncoding {
     /// following a `-----BEGIN PRIVATE KEY-----` header.
     ///
     /// <https://tls.mbed.org/kb/cryptography/asn1-key-structures-in-der-and-pem>
-    ///
-    /// Important: Encoding multi prime keys isn't supported. See [RustCrypto/RSA#66](https://github.com/RustCrypto/RSA/issues/66) for more info 
     fn to_pkcs8(&self) -> Result<Vec<u8>>;
 }
 

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -11,6 +11,7 @@ use simple_asn1::{to_der, ASN1Block, BigInt};
 use std::prelude::v1::*;
 use std::{vec, format};
 
+const BYTE_BIT_SIZE: usize = 8;
 const DEFAULT_ENCODING_CONFIG: EncodeConfig = EncodeConfig {
     line_ending: LineEnding::LF,
 };
@@ -329,7 +330,7 @@ pub trait PublicKeyEncoding: PublicKey {
         let alg = ASN1Block::Sequence(0, vec![oid]);
 
         let bz = self.to_pkcs1()?;
-        let octet_string = ASN1Block::BitString(0, bz.len() * 8, bz);
+        let octet_string = ASN1Block::BitString(0, bz.len() * BYTE_BIT_SIZE, bz);
         let blocks = vec![alg, octet_string];
 
         to_der(&ASN1Block::Sequence(0, blocks)).map_err(|e| Error::EncodeError {

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -26,6 +26,8 @@ pub trait PrivateKeyPemEncoding: PrivateKeyEncoding {
     /// Encodes the key with the header:
     /// `-----BEGIN <name> PRIVATE KEY-----`
     ///
+    /// Important: Encoding multi prime keys isn't supported. See [RustCrypto/RSA#66](https://github.com/RustCrypto/RSA/issues/66) for more info 
+    ///
     /// # Example
     ///
     /// ```
@@ -43,6 +45,8 @@ pub trait PrivateKeyPemEncoding: PrivateKeyEncoding {
     }
 
     /// Converts a Private key into `PKCS1` encoded bytes in pem format with encoding config.
+    ///
+    /// Important: Encoding multi prime keys isn't supported. See [RustCrypto/RSA#66](https://github.com/RustCrypto/RSA/issues/66) for more info 
     ///
     /// # Example
     /// ```
@@ -70,6 +74,8 @@ pub trait PrivateKeyPemEncoding: PrivateKeyEncoding {
     /// Encodes the key with the header:
     /// `-----BEGIN PRIVATE KEY-----`
     ///
+    /// Important: Encoding multi prime keys isn't supported. See [RustCrypto/RSA#66](https://github.com/RustCrypto/RSA/issues/66) for more info 
+    ///
     /// # Example
     ///
     /// ```
@@ -87,6 +93,8 @@ pub trait PrivateKeyPemEncoding: PrivateKeyEncoding {
     }
 
     /// Converts a Private key into `PKCS8` encoded bytes in pem format with encoding config.
+    ///
+    /// Important: Encoding multi prime keys isn't supported. See [RustCrypto/RSA#66](https://github.com/RustCrypto/RSA/issues/66) for more info 
     ///
     /// # Example
     /// ```
@@ -229,9 +237,9 @@ pub trait PrivateKeyEncoding {
     /// This data will be `base64` encoded which would be used
     /// following a `-----BEGIN <name> PRIVATE KEY-----` header.
     ///
-    /// Important: Encoding multi prime keys isn't supported
-    ///
     /// <https://tls.mbed.org/kb/cryptography/asn1-key-structures-in-der-and-pem>
+    ///
+    /// Important: Encoding multi prime keys isn't supported. See [RustCrypto/RSA#66](https://github.com/RustCrypto/RSA/issues/66) for more info 
     fn to_pkcs1(&self) -> Result<Vec<u8>>;
 
     /// Encodes a Private key to into `PKCS8` bytes.
@@ -239,9 +247,9 @@ pub trait PrivateKeyEncoding {
     /// This data will be `base64` encoded which would be used
     /// following a `-----BEGIN PRIVATE KEY-----` header.
     ///
-    /// Important: Encoding multi prime keys isn't supported
-    ///
     /// <https://tls.mbed.org/kb/cryptography/asn1-key-structures-in-der-and-pem>
+    ///
+    /// Important: Encoding multi prime keys isn't supported. See [RustCrypto/RSA#66](https://github.com/RustCrypto/RSA/issues/66) for more info 
     fn to_pkcs8(&self) -> Result<Vec<u8>>;
 }
 
@@ -250,7 +258,7 @@ impl PrivateKeyEncoding for RSAPrivateKey {
         // Check if the key is multi prime
         if self.primes.len() > 2 {
             return Err(Error::EncodeError {
-                reason: "multi prime key encoding isn't supported".into(),
+                reason: "multi prime key encoding isn't supported. see RustCrypto/RSA#66".into(),
             });
         }
 


### PR DESCRIPTION
Reasons for the incompatibility are stated in [this comment](https://github.com/RustCrypto/RSA/issues/63#issuecomment-696336493)

Changes were made according to [RFC 3447; Appendix A.1.2](https://tools.ietf.org/html/rfc3447#appendix-A.1.2)

Closes #63 