### PR TITLE
fix: pin subtle to 2.2.3 to avoid MSRV downgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         rust:
           - 1.36.0
           - stable
-          - nightly
+          # - nightly
         target:
           - x86_64-unknown-linux-gnu
           - thumbv7m-none-eabi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ num-iter = { version = "0.1.37", default-features = false }
 lazy_static = { version = "1.3.0", features = ["spin_no_std"] }
 rand = { version = "0.7.0", default-features = false }
 byteorder = { version = "1.3.1", default-features = false }
-subtle = { version = "=2.0.0", default-features = false }
+subtle = { version = "=2.1.1", default-features = false }
 simple_asn1 = { version = "0.4", optional = true }
 pem = { version = "0.8", optional = true }
 digest = { version = "0.9.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ num-iter = { version = "0.1.37", default-features = false }
 lazy_static = { version = "1.3.0", features = ["spin_no_std"] }
 rand = { version = "0.7.0", default-features = false }
 byteorder = { version = "1.3.1", default-features = false }
-subtle = { version = "2.0.0", default-features = false }
+subtle = { version = "=2.2.3", default-features = false }
 simple_asn1 = { version = "0.4", optional = true }
 pem = { version = "0.8", optional = true }
 digest = { version = "0.9.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ num-iter = { version = "0.1.37", default-features = false }
 lazy_static = { version = "1.3.0", features = ["spin_no_std"] }
 rand = { version = "0.7.0", default-features = false }
 byteorder = { version = "1.3.1", default-features = false }
-subtle = { version = "=2.2.3", default-features = false }
+subtle = { version = "=2.1.1", default-features = false }
 simple_asn1 = { version = "0.4", optional = true }
 pem = { version = "0.8", optional = true }
 digest = { version = "0.9.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ num-iter = { version = "0.1.37", default-features = false }
 lazy_static = { version = "1.3.0", features = ["spin_no_std"] }
 rand = { version = "0.7.0", default-features = false }
 byteorder = { version = "1.3.1", default-features = false }
-subtle = { version = "=2.1.1", default-features = false }
+subtle = { version = "=2.0.0", default-features = false }
 simple_asn1 = { version = "0.4", optional = true }
 pem = { version = "0.8", optional = true }
 digest = { version = "0.9.0", default-features = false }


### PR DESCRIPTION
Ref #65 