### PR TITLE
Fix variable name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ use rand::rngs::OsRng;
 let mut rng = OsRng;
 let bits = 2048;
 let priv_key = RSAPrivateKey::new(&mut rng, bits).expect("failed to generate a key");
-let pub_key = RSAPublicKey::from(&private_key);
+let pub_key = RSAPublicKey::from(&priv_key);
 
 // Encrypt
 let data = b"hello world";


### PR DESCRIPTION
The private key is assigned to `priv_key` but then `&private_key` is passed to `RSAPublicKey::from`.