### PR TITLE
remove std requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ lazy_static = { version = "1.3.0", features = ["spin_no_std"] }
 rand = { version = "0.8.0", features = ["std_rng"], default-features = false }
 byteorder = { version = "1.3.1", default-features = false }
 subtle = { version = "2.1.1", default-features = false }
-simple_asn1 = { version = "0.5", optional = true }
+simple_asn1 = { version = "0.5" }
 pem = { version = "0.8", optional = true }
 digest = { version = "0.9.0", default-features = false }
 
@@ -59,5 +59,5 @@ default = ["std", "pem"]
 nightly = ["subtle/nightly", "num-bigint/nightly"]
 serde = ["num-bigint/serde", "serde_crate"]
 expose-internals = []
-std = ["alloc", "simple_asn1", "digest/std", "rand/std"]
+std = ["alloc", "digest/std", "rand/std"]
 alloc = ["digest/alloc"]

--- a/src/key.rs
+++ b/src/key.rs
@@ -248,7 +248,6 @@ impl RSAPublicKey {
     /// let der_bytes = base64::decode(&der_encoded).expect("failed to decode base64 content");
     /// let public_key = RSAPublicKey::from_pkcs1(&der_bytes).expect("failed to parse key");
     /// ```
-    #[cfg(feature = "std")]
     pub fn from_pkcs1(der: &[u8]) -> Result<RSAPublicKey> {
         crate::parse::parse_public_key_pkcs1(der)
     }
@@ -283,7 +282,6 @@ impl RSAPublicKey {
     /// let der_bytes = base64::decode(&der_encoded).expect("failed to decode base64 content");
     /// let public_key = RSAPublicKey::from_pkcs8(&der_bytes).expect("failed to parse key");
     /// ```
-    #[cfg(feature = "std")]
     pub fn from_pkcs8(der: &[u8]) -> Result<RSAPublicKey> {
         crate::parse::parse_public_key_pkcs8(der)
     }
@@ -408,7 +406,6 @@ impl RSAPrivateKey {
     /// let der_bytes = base64::decode(&der_encoded).expect("failed to decode base64 content");
     /// let private_key = RSAPrivateKey::from_pkcs1(&der_bytes).expect("failed to parse key");
     /// ```
-    #[cfg(feature = "std")]
     pub fn from_pkcs1(der: &[u8]) -> Result<RSAPrivateKey> {
         crate::parse::parse_private_key_pkcs1(der)
     }
@@ -449,7 +446,6 @@ impl RSAPrivateKey {
     /// let der_bytes = base64::decode(&der_encoded).expect("failed to decode base64 content");
     /// let private_key = RSAPrivateKey::from_pkcs8(&der_bytes).expect("failed to parse key");
     /// ```
-    #[cfg(feature = "std")]
     pub fn from_pkcs8(der: &[u8]) -> Result<RSAPrivateKey> {
         crate::parse::parse_private_key_pkcs8(der)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,6 @@ mod encode;
 mod key;
 #[cfg(feature = "alloc")]
 mod oaep;
-#[cfg(feature = "std")]
 mod parse;
 #[cfg(feature = "alloc")]
 mod pkcs1v15;


### PR DESCRIPTION
Hi, I remove the std requirement in order to use it in WebAssembly.
Is there a reason for this restriction ?