### PR TITLE
Add possibility to allow a different hash function for MGF mask function

### DIFF
--- a/src/oaep.rs
+++ b/src/oaep.rs
@@ -23,6 +23,7 @@ pub fn encrypt<R: Rng, K: PublicKey>(
     pub_key: &K,
     msg: &[u8],
     digest: &mut dyn DynDigest,
+    mgf_digest: &mut dyn DynDigest,
     label: Option<String>,
 ) -> Result<Vec<u8>> {
     key::check_public(pub_key)?;
@@ -55,8 +56,8 @@ pub fn encrypt<R: Rng, K: PublicKey>(
     db[db_len - msg.len() - 1] = 1;
     db[db_len - msg.len()..].copy_from_slice(msg);
 
-    mgf1_xor(db, digest, seed);
-    mgf1_xor(seed, digest, db);
+    mgf1_xor(db, mgf_digest, seed);
+    mgf1_xor(seed, mgf_digest, db);
 
     pub_key.raw_encryption_primitive(&em, pub_key.size())
 }
@@ -75,11 +76,12 @@ pub fn decrypt<R: Rng, SK: PrivateKey>(
     priv_key: &SK,
     ciphertext: &[u8],
     digest: &mut dyn DynDigest,
+    mgf_digest: &mut dyn DynDigest,
     label: Option<String>,
 ) -> Result<Vec<u8>> {
     key::check_public(priv_key)?;
 
-    let res = decrypt_inner(rng, priv_key, ciphertext, digest, label)?;
+    let res = decrypt_inner(rng, priv_key, ciphertext, digest, mgf_digest, label)?;
     if res.is_none().into() {
         return Err(Error::Decryption);
     }
@@ -98,6 +100,7 @@ fn decrypt_inner<R: Rng, SK: PrivateKey>(
     priv_key: &SK,
     ciphertext: &[u8],
     digest: &mut dyn DynDigest,
+    mgf_digest: &mut dyn DynDigest,
     label: Option<String>,
 ) -> Result<CtOption<(Vec<u8>, u32)>> {
     let k = priv_key.size();
@@ -127,8 +130,8 @@ fn decrypt_inner<R: Rng, SK: PrivateKey>(
     let (_, payload) = em.split_at_mut(1);
     let (seed, db) = payload.split_at_mut(h_size);
 
-    mgf1_xor(seed, digest, db);
-    mgf1_xor(db, digest, seed);
+    mgf1_xor(seed, mgf_digest, db);
+    mgf1_xor(db, mgf_digest, seed);
 
     let hash_are_equal = db[0..h_size].ct_eq(expected_p_hash);
 

--- a/src/oaep.rs
+++ b/src/oaep.rs
@@ -15,7 +15,7 @@ use crate::key::{self, PrivateKey, PublicKey};
 const MAX_LABEL_LEN: u64 = 2_305_843_009_213_693_951;
 
 /// Encrypts the given message with RSA and the padding
-/// scheme from PKCS#1 OAEP.  The message must be no longer than the
+/// scheme from [PKCS#1 OAEP](https://datatracker.ietf.org/doc/html/rfc3447#section-7.1.1).  The message must be no longer than the
 /// length of the public modulus minus (2+ 2*hash.size()).
 #[inline]
 pub fn encrypt<R: Rng, K: PublicKey>(
@@ -62,7 +62,7 @@ pub fn encrypt<R: Rng, K: PublicKey>(
     pub_key.raw_encryption_primitive(&em, pub_key.size())
 }
 
-/// Decrypts a plaintext using RSA and the padding scheme from pkcs1# OAEP
+/// Decrypts a plaintext using RSA and the padding scheme from [pkcs1# OAEP](https://datatracker.ietf.org/doc/html/rfc3447#section-7.1.2)
 /// If an `rng` is passed, it uses RSA blinding to avoid timing side-channel attacks.
 ///
 /// Note that whether this function returns an error or not discloses secret

--- a/src/padding.rs
+++ b/src/padding.rs
@@ -1,6 +1,6 @@
-use core::fmt;
-use alloc::string::{String, ToString};
 use alloc::boxed::Box;
+use alloc::string::{String, ToString};
+use core::fmt;
 
 use digest::{Digest, DynDigest};
 use rand::RngCore;
@@ -13,7 +13,16 @@ pub enum PaddingScheme {
     PKCS1v15Encrypt,
     /// Sign and Verify using PKCS1v15 padding.
     PKCS1v15Sign { hash: Option<Hash> },
-    /// Encryption and Decryption using OAEP padding.
+    /// Encryption and Decryption using [OAEP padding](https://datatracker.ietf.org/doc/html/rfc3447#section-7.1.1).
+    /// The OAEP padding scheme relays on a hash function `digest`, which fixes the output length of the various
+    /// padding blocks and hence fixes the max length of the plain-text to be `m = n - 2 * h_len - 2`, where `n` is the size of the 
+    /// modulus of the public key. Further, if a label is specified, it represents the hash function used to hash the label.
+    /// On the other hand, to prevent chosen plain-text attacks, a mask generation function is used. For OAEP this 
+    /// is [MGF1](https://datatracker.ietf.org/doc/html/rfc2437#section-10.2.1), which is a mask generation function
+    /// based on a hash function `mgf_digest`. 
+    /// 
+    /// The two hash functions can, but don't need to be the same. A prominent example is the `AndroidKeyStore`, which
+    /// uses a OAEP padding with `digest` being SHA-256 _but_ `mgf_digest` being SHA-1.
     OAEP {
         digest: Box<dyn DynDigest>,
         mgf_digest: Box<dyn DynDigest>,
@@ -55,29 +64,80 @@ impl PaddingScheme {
         PaddingScheme::PKCS1v15Sign { hash }
     }
 
-    pub fn new_oaep_with_mgf_hash<T: 'static + Digest + DynDigest, U: 'static + Digest + DynDigest>() -> Self {
+    /// Create a new OAEP `PaddingScheme`, using `T` for the OAEP hash function, and `U` for the MGF1 hash function.
+    /// If a label is needed use `PaddingScheme::new_oaep_with_label` or `PaddingScheme::new_oaep_with_mgf_hash_with_label`.
+    /// 
+    /// # Example
+    /// ```
+    ///     use sha1::Sha1;
+    ///     use sha2::Sha256;
+    ///     use rand::rngs::OsRng;
+    ///     use rsa::{BigUint, RSAPublicKey, PaddingScheme, PublicKey};
+
+    ///     let n = base64::decode("ALHgDoZmBQIx+jTmgeeHW6KsPOrj11f6CvWsiRleJlQpW77AwSZhd21ZDmlTKfaIHBSUxRUsuYNh7E2SHx8rkFVCQA2/gXkZ5GK2IUbzSTio9qXA25MWHvVxjMfKSL8ZAxZyKbrG94FLLszFAFOaiLLY8ECs7g+dXOriYtBwLUJK+lppbd+El+8ZA/zH0bk7vbqph5pIoiWggxwdq3mEz4LnrUln7r6dagSQzYErKewY8GADVpXcq5mfHC1xF2DFBub7bFjMVM5fHq7RK+pG5xjNDiYITbhLYrbVv3X0z75OvN0dY49ITWjM7xyvMWJXVJS7sJlgmCCL6RwWgP8PhcE=").unwrap();
+    ///     let e = base64::decode("AQAB").unwrap();
+    ///     
+    ///     let key = RSAPublicKey::new(BigUint::from_bytes_be(&n), BigUint::from_bytes_be(&e)).unwrap();
+    ///     let padding = PaddingScheme::new_oaep_with_mgf_hash::<Sha256, Sha1>();
+    ///     let encrypted_data = key.encrypt(&mut OsRng, padding, b"secret").unwrap();
+    /// ```
+    pub fn new_oaep_with_mgf_hash<
+        T: 'static + Digest + DynDigest,
+        U: 'static + Digest + DynDigest,
+    >() -> Self {
         PaddingScheme::OAEP {
             digest: Box::new(T::new()),
             mgf_digest: Box::new(U::new()),
             label: None,
         }
     }
+
+    /// Create a new OAEP `PaddingScheme` with the specified hash function.
+    /// Further, the same hash function is used for the MGF1 mask generation function.
+    /// 
+    /// # Example
+    /// ```
+    ///     use sha1::Sha1;
+    ///     use sha2::Sha256;
+    ///     use rand::rngs::OsRng;
+    ///     use rsa::{BigUint, RSAPublicKey, PaddingScheme, PublicKey};
+
+    ///     let n = base64::decode("ALHgDoZmBQIx+jTmgeeHW6KsPOrj11f6CvWsiRleJlQpW77AwSZhd21ZDmlTKfaIHBSUxRUsuYNh7E2SHx8rkFVCQA2/gXkZ5GK2IUbzSTio9qXA25MWHvVxjMfKSL8ZAxZyKbrG94FLLszFAFOaiLLY8ECs7g+dXOriYtBwLUJK+lppbd+El+8ZA/zH0bk7vbqph5pIoiWggxwdq3mEz4LnrUln7r6dagSQzYErKewY8GADVpXcq5mfHC1xF2DFBub7bFjMVM5fHq7RK+pG5xjNDiYITbhLYrbVv3X0z75OvN0dY49ITWjM7xyvMWJXVJS7sJlgmCCL6RwWgP8PhcE=").unwrap();
+    ///     let e = base64::decode("AQAB").unwrap();
+    ///     
+    ///     let key = RSAPublicKey::new(BigUint::from_bytes_be(&n), BigUint::from_bytes_be(&e)).unwrap();
+    ///     let padding = PaddingScheme::new_oaep::<Sha256>();
+    ///     let encrypted_data = key.encrypt(&mut OsRng, padding, b"secret").unwrap();
+    /// ```
     pub fn new_oaep<T: 'static + Digest + DynDigest>() -> Self {
-         PaddingScheme::OAEP {
+        PaddingScheme::OAEP {
             digest: Box::new(T::new()),
             mgf_digest: Box::new(T::new()),
             label: None,
         }
     }
 
-    pub fn new_oaep_with_mgf_hash_with_label<T: 'static + Digest + DynDigest, U: 'static + Digest + DynDigest,  S: AsRef<str>>(label: S) -> Self {
+    /// Create a new OAEP `PaddingScheme`, with `T` being the OAEP hash function and `U`
+    /// being the hash function used for the MGF1 mask generation function. Note that `T`
+    /// is also used to hash the label.
+    pub fn new_oaep_with_mgf_hash_with_label<
+        T: 'static + Digest + DynDigest,
+        U: 'static + Digest + DynDigest,
+        S: AsRef<str>,
+    >(
+        label: S,
+    ) -> Self {
         PaddingScheme::OAEP {
             digest: Box::new(T::new()),
             mgf_digest: Box::new(U::new()),
             label: Some(label.as_ref().to_string()),
         }
     }
-     pub fn new_oaep_with_label<T: 'static + Digest + DynDigest,  S: AsRef<str>>(label: S) -> Self {
+
+    /// Create a new OAEP `PaddingScheme` with the specified hash function.
+    /// The _same_ hash function will be used for hashing the label as well as
+    /// for the mask generation function.
+    pub fn new_oaep_with_label<T: 'static + Digest + DynDigest, S: AsRef<str>>(label: S) -> Self {
         PaddingScheme::OAEP {
             digest: Box::new(T::new()),
             mgf_digest: Box::new(T::new()),

--- a/src/padding.rs
+++ b/src/padding.rs
@@ -93,7 +93,6 @@ impl PaddingScheme {
     }
 
     /// Create a new OAEP `PaddingScheme`, using `T` as the hash function for both the default (empty) label and for MGF1.
-    /// Further, the same hash function is used for the MGF1 mask generation function.
     ///
     /// # Example
     /// ```

--- a/src/padding.rs
+++ b/src/padding.rs
@@ -16,6 +16,7 @@ pub enum PaddingScheme {
     /// Encryption and Decryption using OAEP padding.
     OAEP {
         digest: Box<dyn DynDigest>,
+        mgf_digest: Box<dyn DynDigest>,
         label: Option<String>,
     },
     /// Sign and Verify using PSS padding.
@@ -54,16 +55,32 @@ impl PaddingScheme {
         PaddingScheme::PKCS1v15Sign { hash }
     }
 
-    pub fn new_oaep<T: 'static + Digest + DynDigest>() -> Self {
+    pub fn new_oaep_with_mgf_hash<T: 'static + Digest + DynDigest, U: 'static + Digest + DynDigest>() -> Self {
         PaddingScheme::OAEP {
             digest: Box::new(T::new()),
+            mgf_digest: Box::new(U::new()),
+            label: None,
+        }
+    }
+    pub fn new_oaep<T: 'static + Digest + DynDigest>() -> Self {
+         PaddingScheme::OAEP {
+            digest: Box::new(T::new()),
+            mgf_digest: Box::new(T::new()),
             label: None,
         }
     }
 
-    pub fn new_oaep_with_label<T: 'static + Digest + DynDigest, S: AsRef<str>>(label: S) -> Self {
+    pub fn new_oaep_with_mgf_hash_with_label<T: 'static + Digest + DynDigest, U: 'static + Digest + DynDigest,  S: AsRef<str>>(label: S) -> Self {
         PaddingScheme::OAEP {
             digest: Box::new(T::new()),
+            mgf_digest: Box::new(U::new()),
+            label: Some(label.as_ref().to_string()),
+        }
+    }
+     pub fn new_oaep_with_label<T: 'static + Digest + DynDigest,  S: AsRef<str>>(label: S) -> Self {
+        PaddingScheme::OAEP {
+            digest: Box::new(T::new()),
+            mgf_digest: Box::new(T::new()),
             label: Some(label.as_ref().to_string()),
         }
     }


### PR DESCRIPTION
This pull request adds a new field to the OAEP padding to allow for a different hash function for the MGF mask function. This is especially needed, when trying to be compatible with other algorithms, more specifically the `AndroidKeyStore`. The `AndroidKeyStore` only supports RSA encryption with SHA256 and SHA1 for the MGF mask function.

 For compatibility the existing functions were adjusted to replicate the previous behaviour to use the same hash function.

To the OAEP-Padding  two new functions `new_oaep_with_mgf_hash` and `new_oaep_with_mgf_hash_with_labe` were added to allow specifying the MGF hash function.