### PR TITLE
Lock `zeroize` to v1.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ pem = { version = "0.8", optional = true }
 digest = { version = "0.9.0", default-features = false }
 
 [dependencies.zeroize]
-version = "1.1.0"
+version = "=1.3" # zeroize 1.4 is MSRV 1.51+
 features = ["alloc", "zeroize_derive"]
 
 [dependencies.serde_crate]


### PR DESCRIPTION
1.4 requires MSRV 1.51