### PR TITLE
Remove `extern crate` directives

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -1,5 +1,6 @@
 use alloc::vec::Vec;
 use core::ops::Deref;
+use lazy_static::lazy_static;
 use num_bigint::traits::ModInverse;
 use num_bigint::Sign::Plus;
 use num_bigint::{BigInt, BigUint};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,19 +64,6 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-#[macro_use]
-extern crate lazy_static;
-
-#[cfg(feature = "serde")]
-extern crate serde_crate;
-
-#[cfg(test)]
-extern crate base64;
-#[cfg(test)]
-extern crate hex;
-#[cfg(all(test, feature = "serde"))]
-extern crate serde_test;
-
 #[cfg(feature = "alloc")]
 pub use num_bigint::BigUint;
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -2,7 +2,7 @@ use crate::{
     errors::{Error, Result},
     RSAPrivateKey, RSAPublicKey,
 };
-use simple_asn1::{ASN1Block, ASN1DecodeErr, BigUint, OID};
+use simple_asn1::{ASN1Block, ASN1DecodeErr, OID};
 
 use alloc::format;
 use alloc::string::ToString;


### PR DESCRIPTION
These are no longer needed as of the 2018 edition