### PR TITLE
docs(readme): only optimizing num-bigint-dig is enough to unlock most speedups

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,15 @@ assert_eq!(&data[..], &dec_data[..]);
 ```
 
 > **Note:** If you encounter unusually slow key generation time while using `RSAPrivateKey::new` you can try to compile in release mode or add the following to your `Cargo.toml`. Key generation is much faster when building with higher optimization levels, but this will increase the compile time a bit.
-> ```
+> ```toml
 > [profile.debug]
+> opt-level = 3
+> ```
+> If you don't want to turn on optimizations for all dependencies,
+> you can only optimize the `num-bigint-dig` dependency. This should
+> give most of the speedups.
+> ```toml
+> [profile.dev.package.num-bigint-dig]
 > opt-level = 3
 > ```
 


### PR DESCRIPTION
I saw a merge of #61 and thought that integrating the limited optimization instruction I found would be a nice idea.