### PR TITLE
feat: derive Hash for `RsaPublicKey`

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -39,7 +39,7 @@ pub trait PublicKeyParts {
 pub trait PrivateKey: DecryptionPrimitive + PublicKeyParts {}
 
 /// Represents the public part of an RSA key.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),


### PR DESCRIPTION
It would be great for the RsaPublicKey to derive the Hash trait.
All the internal fields of RsaPublicKey already implement the Hash trait, it is enough to automatically derive.
By doing so, it becomes possible to store RsaPublicKey e.g. in an HashSet.