### PR TITLE
Add a sha1 feature to enable pkcs8/sha1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ std = ["alloc", "digest/std", "pkcs1/std", "pkcs8/std", "rand/std"]
 alloc = ["digest/alloc", "pkcs1/alloc", "pkcs8/alloc", "pkcs8/pkcs1"]
 pem = ["alloc", "pkcs1/pem", "pkcs8/pem"]
 pkcs5 = ["pkcs8/encryption"]
+sha1 = ["pkcs8/sha1"]
 
 [package.metadata.docs.rs]
 features = ["std", "pem", "serde"]


### PR DESCRIPTION
Currently, the RSA crate doesn't have a feature to enable the sha1 feature in the pkcs8 crate. It would be great if we could add this feature to enable sha1 from this crate.