### PR TITLE
refactor: remove `lazy_static` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ num-bigint = { version = "0.7.0", features = ["i128", "u64_digit", "prime", "zer
 num-traits = { version= "0.2.9", default-features = false, features = ["libm"] }
 num-integer = { version = "0.1.39", default-features = false }
 num-iter = { version = "0.1.37", default-features = false }
-lazy_static = { version = "1.3.0", features = ["spin_no_std"] }
 rand = { version = "0.8.0", features = ["std_rng"], default-features = false }
 byteorder = { version = "1.3.1", default-features = false }
 subtle = { version = "2.1.1", default-features = false }


### PR DESCRIPTION
This also speeds up `check_public` by about 30%, as the compiler can optimize it by taking into account the constant values.