### PR TITLE
Adds example of reading/writing RSA keys to/from file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,9 @@ jobs:
       - name: Examples
         uses: actions-rs/cargo@v1
         with:
-          use-cross: true
+          use-cross: false
           command: build 
-          args: --examples --all --target ${{ matrix.target }} --verbose ${{ matrix.args }}
+          args: --examples --all --verbose ${{ matrix.args }}
 
       - name: Test
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,13 @@ jobs:
           use-cross: true
           command: build
           args: --target ${{ matrix.target }} --verbose ${{ matrix.args }}
+      
+      - name: Examples
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build --examples --all
+          args: --target ${{ matrix.target }} --verbose ${{ matrix.args }}
 
       - name: Test
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,8 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           use-cross: true
-          command: build --examples --all
-          args: --target ${{ matrix.target }} --verbose ${{ matrix.args }}
+          command: build 
+          args: --examples --all --target ${{ matrix.target }} --verbose ${{ matrix.args }}
 
       - name: Test
         uses: actions-rs/cargo@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+*id_rsa*

--- a/examples/key_retrieval.rs
+++ b/examples/key_retrieval.rs
@@ -1,0 +1,52 @@
+use rand::rngs::OsRng;
+use rsa::pkcs1::{FromRsaPrivateKey, FromRsaPublicKey, ToRsaPrivateKey, ToRsaPublicKey};
+use rsa::{PaddingScheme, PublicKey, RsaPrivateKey, RsaPublicKey};
+
+use std::fs::{read_to_string, File};
+use std::io::Write;
+use std::path::Path;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut rng = OsRng;
+    let bits = 2048;
+
+    let priv_key_path = Path::new("id_rsa");
+    let pub_key_path = Path::new("id_rsa.pub");
+    {
+        // Create private key and write to .pem file
+        let private_key = RsaPrivateKey::new(&mut rng, bits)?;
+        let priv_key_pem = private_key.to_pkcs1_pem()?;
+
+        let mut priv_key_file = File::create(priv_key_path)?;
+        priv_key_file.write_all(priv_key_pem.as_bytes())?;
+
+        // Derive public key and write to .pen file
+        let public_key = RsaPublicKey::from(&private_key);
+        let pub_key_pem = public_key.to_pkcs1_pem()?;
+
+        let mut pub_key_file = File::create(pub_key_path)?;
+        pub_key_file.write_all(pub_key_pem.as_bytes())?;
+    }
+
+    // Retrieve public key from .pem file
+    let public_key_pem = read_to_string(pub_key_path)?;
+    let public_key = RsaPublicKey::from_pkcs1_pem(&public_key_pem)?;
+    // Retrieve private key from .pem file
+    let private_key_pem = read_to_string(priv_key_path)?;
+    let private_key = RsaPrivateKey::from_pkcs1_pem(&private_key_pem)?;
+
+    // Encrypt data using public key
+    let data = b"hello world";
+    let padding = PaddingScheme::new_pkcs1v15_encrypt();
+    let enc_data = public_key
+        .encrypt(&mut rng, padding, &data[..])
+        .expect("failed to encrypt");
+    assert_ne!(&data[..], &enc_data[..]);
+
+    // Decrypt data using private key
+    let padding = PaddingScheme::new_pkcs1v15_encrypt();
+    let dec_data = private_key
+        .decrypt(padding, &enc_data)
+        .expect("failed to decrypt");
+    assert_eq!(&data[..], &dec_data[..]);
+}

--- a/src/internals.rs
+++ b/src/internals.rs
@@ -98,7 +98,7 @@ pub fn decrypt<R: Rng>(
     match ir {
         Some(ref ir) => {
             // unblind
-            Ok(unblind(priv_key, &m, &ir))
+            Ok(unblind(priv_key, &m, ir))
         }
         None => Ok(m),
     }

--- a/src/pkcs1v15.rs
+++ b/src/pkcs1v15.rs
@@ -86,7 +86,7 @@ pub fn sign<R: Rng, SK: PrivateKey>(
     em[0] = 0;
     em[1] = 1;
     em[k - t_len - 1] = 0;
-    em[k - t_len..k - hash_len].copy_from_slice(&prefix);
+    em[k - t_len..k - hash_len].copy_from_slice(prefix);
     em[k - hash_len..k].copy_from_slice(hashed);
 
     priv_key.raw_decryption_primitive(rng, &em, priv_key.size())
@@ -114,7 +114,7 @@ pub fn verify<PK: PublicKey>(
     let mut ok = em[0].ct_eq(&0u8);
     ok &= em[1].ct_eq(&1u8);
     ok &= em[k - hash_len..k].ct_eq(hashed);
-    ok &= em[k - t_len..k - hash_len].ct_eq(&prefix);
+    ok &= em[k - t_len..k - hash_len].ct_eq(prefix);
     ok &= em[k - t_len - 1].ct_eq(&0u8);
 
     for el in em.iter().skip(2).take(k - t_len - 3) {

--- a/src/pss.rs
+++ b/src/pss.rs
@@ -124,7 +124,7 @@ fn emsa_pss_encode(
     // 9.  Let dbMask = MGF(H, emLen - hLen - 1).
     //
     // 10. Let maskedDB = DB \xor dbMask.
-    mgf1_xor(db, hash, &h);
+    mgf1_xor(db, hash, h);
 
     // 11. Set the leftmost 8 * em_len - em_bits bits of the leftmost octet in
     //     maskedDB to zero.


### PR DESCRIPTION
Hello,

I started working with the `rsa` crate today, and it took me a while to figure out the idiomatic ways of reading/writing keys to and from .pem files. In retrospect, I can see that the re-export of the `pkcs#` crates offered those methods, but it took a while (I actually re-implemented the with `std::fs::read_to_string` and other methods before finding them). 

I figured that other people might run into a similar issue at some point, so figured I might offer an example in the repository in addition to the documentation, as suggested in #7. I've added the `cargo build --examples --all` to the  Github Actions CI, and `clippy` should be happy. Thanks for your consideration, and happy to make any changes or answer any questions!