### PR TITLE
mark key and pkcs1v15 as public to give access to verify

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,13 +182,13 @@ pub mod padding;
 mod encoding;
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-mod key;
+pub mod key;
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 mod oaep;
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-mod pkcs1v15;
+pub mod pkcs1v15;
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 mod pss;


### PR DESCRIPTION
Enables code like the following to verify signatures using keys extracted from a certificate.

```
            let rsa = RsaPublicKey::from_public_key_der(&enc_spki);
            if let Ok(rsa) = rsa {
                let x = rsa.verify(ps, hash_to_verify, signature);

```