### PR TITLE
Impl `zeroize` without using `zeroize_derive`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,7 @@ subtle = { version = "2.1.1", default-features = false }
 digest = { version = "0.10.0", default-features = false }
 pkcs1 = { version = "0.3.3", default-features = false, features = ["pkcs8"] }
 pkcs8 = { version = "0.8", default-features = false }
-
-[dependencies.zeroize]
-version = ">=1, <1.5" # zeroize 1.4 is MSRV 1.51+
-features = ["alloc", "zeroize_derive"]
+zeroize = { version = "1", features = ["alloc"] }
 
 [dependencies.serde_crate]
 package = "serde"

--- a/src/key.rs
+++ b/src/key.rs
@@ -138,7 +138,7 @@ impl Drop for PrecomputedValues {
 }
 
 /// Contains the precomputed Chinese remainder theorem values.
-#[derive(Debug, Clone, Zeroize)]
+#[derive(Debug, Clone)]
 pub(crate) struct CRTValue {
     /// D mod (prime - 1)
     pub(crate) exp: BigInt,
@@ -146,6 +146,14 @@ pub(crate) struct CRTValue {
     pub(crate) coeff: BigInt,
     /// product of primes prior to this (inc p and q)
     pub(crate) r: BigInt,
+}
+
+impl Zeroize for CRTValue {
+    fn zeroize(&mut self) {
+        self.exp.zeroize();
+        self.coeff.zeroize();
+        self.r.zeroize();
+    }
 }
 
 impl From<RsaPrivateKey> for RsaPublicKey {


### PR DESCRIPTION
The `zeroize_derive` crate has quite a few dependencies, and in particular `syn` is a fairly large one with not-insignificant compile times.

Together with dignifiedquire/num-bigint#35, this will remove the following dependencies from the dependency tree:

- `proc-macro2`
- `quote`
- `syn`
- `synstructure`
- `zeroize_derive`