### PR TITLE
Replace rand dependency with rand_core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,69 +6,56 @@ on:
     branches:
       - master
 
-env:
-  RUST_BACKTRACE: 1
-
 jobs:
   build:
-    name: ${{ matrix.rust }} - ${{ matrix.target }}
     runs-on: ubuntu-latest
-
-    # The build matrix does not yet support 'allow failures' at job level.
-    # See `jobs.nightly` for the active nightly job definition.
     strategy:
       matrix:
         rust:
-          - 1.56.0
+          - 1.56.0 # MSRV
           - stable
-          - nightly
         target:
-          - x86_64-unknown-linux-gnu
-          - thumbv7m-none-eabi
-        include:
-          - rust: nightly
-            target: x86_64-unknown-linux-gnu
-            args: --all-features
-          - target: thumbv7m-none-eabi
-            test-target: arm-unknown-linux-gnueabi
-            args: --no-default-features --features=alloc
-          - rust: stable
-            target: x86_64-unknown-linux-gnu
-            args: --no-default-features --features=std
-        exclude:
-          - rust: 1.56.0
-            target: thumbv7m-none-eabi
-
+          - thumbv7em-none-eabi
+          - wasm32-unknown-unknown
     steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-
-      - name: Install rust
-        uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v2
+      - uses: RustCrypto/actions/cargo-cache@master
+      - uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ matrix.rust || 'stable' }}
-          target: ${{ matrix.target }}
           profile: minimal
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
           override: true
+      - run: cargo build --no-default-features --target ${{ matrix.target }}
 
-      - name: Build
-        uses: actions-rs/cargo@v1
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.56.0 # MSRV
+          - stable
+    steps:
+      - uses: actions/checkout@v2
+      - uses: RustCrypto/actions/cargo-cache@master
+      - uses: actions-rs/toolchain@v1
         with:
-          use-cross: true
-          command: build
-          args: --target ${{ matrix.target }} --verbose ${{ matrix.args }}
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - uses: RustCrypto/actions/cargo-hack-install@master
+      - run: cargo hack test --release --feature-powerset --exclude-features nightly,getrandom,serde
+      - run: cargo test --release --features getrandom
+      - run: cargo test --release --features serde
 
-      - name: Test
-        uses: actions-rs/cargo@v1
+  nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: RustCrypto/actions/cargo-cache@master
+      - uses: actions-rs/toolchain@v1
         with:
-          use-cross: true
-          command: test
-          args: --target ${{ matrix.test-target || matrix.target }} --verbose ${{ matrix.args }}
-
-      - name: Bench
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: bench
-          args: --target ${{ matrix.test-target || matrix.target }} --verbose --no-run ${{ matrix.args }}
-        if: matrix.rust == 'nightly'
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - run: cargo test --release --features nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ num-bigint = { version = "0.8.1", features = ["i128", "u64_digit", "prime", "zer
 num-traits = { version= "0.2.9", default-features = false, features = ["libm"] }
 num-integer = { version = "0.1.39", default-features = false }
 num-iter = { version = "0.1.37", default-features = false }
-rand = { version = "0.8.0", features = ["std_rng"], default-features = false }
+rand_core = { version = "0.6", default-features = false }
 byteorder = { version = "1.3.1", default-features = false }
 subtle = { version = "2.1.1", default-features = false }
-digest = { version = "0.10.0", default-features = false }
-pkcs1 = { version = "0.3.3", default-features = false, features = ["pkcs8"] }
-pkcs8 = { version = "0.8", default-features = false }
+digest = { version = "0.10.0", default-features = false, features = ["alloc"] }
+pkcs1 = { version = "0.3.3", default-features = false, features = ["pkcs8", "alloc"] }
+pkcs8 = { version = "0.8", default-features = false, features = ["alloc"] }
 zeroize = { version = "1", features = ["alloc"] }
 
 [dependencies.serde_crate]
@@ -33,34 +33,30 @@ default-features = false
 features = ["derive"]
 
 [dev-dependencies]
-base64 = "0.13.0"
-hex = "0.4.0"
+base64ct = { version = "1", features = ["alloc"] }
 hex-literal = "0.3.3"
 serde_test = "1.0.89"
-rand_xorshift = "0.3.0"
-sha-1 = { default-features = false, version = "0.10.0" }
-sha2 = { default-features = false, version = "0.10.0" }
-sha3 = { default-features = false, version = "0.10.0" }
+rand_xorshift = "0.3"
+rand_chacha = "0.3"
+rand = "0.8"
+rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
+sha1 = { version = "0.10.1", default-features = false }
+sha2 = { version = "0.10.2", default-features = false }
+sha3 = { version = "0.10.1", default-features = false }
 
 [[bench]]
 name = "key"
-
-[profile.release]
-# debug = true
-
-[profile.bench]
-# debug = true
 
 [features]
 default = ["std", "pem"]
 nightly = ["num-bigint/nightly"]
 serde = ["num-bigint/serde", "serde_crate"]
 expose-internals = []
-std = ["alloc", "digest/std", "pkcs1/std", "pkcs8/std", "rand/std"]
-alloc = ["digest/alloc", "pkcs1/alloc", "pkcs8/alloc"]
-pem = ["alloc", "pkcs1/pem", "pkcs8/pem"]
+std = ["digest/std", "pkcs1/std", "pkcs8/std", "rand_core/std"]
+pem = ["pkcs1/pem", "pkcs8/pem"]
 pkcs5 = ["pkcs8/encryption"]
+getrandom = ["rand_core/getrandom"]
 
 [package.metadata.docs.rs]
-features = ["std", "pem", "serde"]
+features = ["std", "pem", "serde", "expose-internals"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/README.md
+++ b/README.md
@@ -15,9 +15,8 @@ A portable RSA implementation in pure Rust.
 
 ```rust
 use rsa::{PublicKey, RsaPrivateKey, RsaPublicKey, PaddingScheme};
-use rand::rngs::OsRng;
 
-let mut rng = OsRng;
+let mut rng = rand::thread_rng();
 let bits = 2048;
 let priv_key = RsaPrivateKey::new(&mut rng, bits).expect("failed to generate a key");
 let pub_key = RsaPublicKey::from(&priv_key);

--- a/benches/key.rs
+++ b/benches/key.rs
@@ -2,10 +2,10 @@
 
 extern crate test;
 
-use base64;
+use base64ct::{Base64, Encoding};
 use num_bigint::BigUint;
 use num_traits::{FromPrimitive, Num};
-use rand::{rngs::StdRng, SeedableRng};
+use rand_chacha::{rand_core::SeedableRng, ChaCha8Rng};
 use rsa::{Hash, PaddingScheme, RsaPrivateKey};
 use sha2::{Digest, Sha256};
 use test::Bencher;
@@ -28,7 +28,7 @@ fn get_key() -> RsaPrivateKey {
 #[bench]
 fn bench_rsa_2048_pkcsv1_decrypt(b: &mut Bencher) {
     let priv_key = get_key();
-    let x = base64::decode(DECRYPT_VAL).unwrap();
+    let x = Base64::decode_vec(DECRYPT_VAL).unwrap();
 
     b.iter(|| {
         let res = priv_key
@@ -42,7 +42,7 @@ fn bench_rsa_2048_pkcsv1_decrypt(b: &mut Bencher) {
 fn bench_rsa_2048_pkcsv1_sign_blinded(b: &mut Bencher) {
     let priv_key = get_key();
     let digest = Sha256::digest(b"testing").to_vec();
-    let mut rng = StdRng::from_seed([1u8; 32]);
+    let mut rng = ChaCha8Rng::from_seed([42; 32]);
 
     b.iter(|| {
         let res = priv_key

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -5,7 +5,7 @@ use num_bigint::{BigUint, RandPrime};
 #[allow(unused_imports)]
 use num_traits::Float;
 use num_traits::{FromPrimitive, One, Zero};
-use rand::Rng;
+use rand_core::{CryptoRng, RngCore};
 
 use crate::errors::{Error, Result};
 use crate::key::RsaPrivateKey;
@@ -28,7 +28,7 @@ const EXP: u64 = 65537;
 ///
 /// [1] US patent 4405829 (1972, expired)
 /// [2] http://www.cacr.math.uwaterloo.ca/techreports/2006/cacr2006-16.pdf
-pub fn generate_multi_prime_key<R: Rng>(
+pub fn generate_multi_prime_key<R: RngCore + CryptoRng>(
     rng: &mut R,
     nprimes: usize,
     bit_size: usize,
@@ -48,7 +48,7 @@ pub fn generate_multi_prime_key<R: Rng>(
 ///
 /// [1] US patent 4405829 (1972, expired)
 /// [2] http://www.cacr.math.uwaterloo.ca/techreports/2006/cacr2006-16.pdf
-pub fn generate_multi_prime_key_with_exp<R: Rng>(
+pub fn generate_multi_prime_key_with_exp<R: RngCore + CryptoRng>(
     rng: &mut R,
     nprimes: usize,
     bit_size: usize,

--- a/src/internals.rs
+++ b/src/internals.rs
@@ -3,7 +3,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use num_bigint::{BigInt, BigUint, IntoBigInt, IntoBigUint, ModInverse, RandBigInt, ToBigInt};
 use num_traits::{One, Signed, Zero};
-use rand::Rng;
+use rand_core::{CryptoRng, RngCore};
 use zeroize::Zeroize;
 
 use crate::errors::{Error, Result};
@@ -18,7 +18,7 @@ pub fn encrypt<K: PublicKeyParts>(key: &K, m: &BigUint) -> BigUint {
 /// Performs raw RSA decryption with no padding, resulting in a plaintext `BigUint`.
 /// Peforms RSA blinding if an `Rng` is passed.
 #[inline]
-pub fn decrypt<R: Rng>(
+pub fn decrypt<R: RngCore + CryptoRng>(
     mut rng: Option<&mut R>,
     priv_key: &RsaPrivateKey,
     c: &BigUint,
@@ -108,7 +108,7 @@ pub fn decrypt<R: Rng>(
 /// Peforms RSA blinding if an `Rng` is passed.
 /// This will also check for errors in the CRT computation.
 #[inline]
-pub fn decrypt_and_check<R: Rng>(
+pub fn decrypt_and_check<R: RngCore + CryptoRng>(
     rng: Option<&mut R>,
     priv_key: &RsaPrivateKey,
     c: &BigUint,
@@ -127,7 +127,11 @@ pub fn decrypt_and_check<R: Rng>(
 }
 
 /// Returns the blinded c, along with the unblinding factor.
-pub fn blind<R: Rng, K: PublicKeyParts>(rng: &mut R, key: &K, c: &BigUint) -> (BigUint, BigUint) {
+pub fn blind<R: RngCore + CryptoRng, K: PublicKeyParts>(
+    rng: &mut R,
+    key: &K,
+    c: &BigUint,
+) -> (BigUint, BigUint) {
     // Blinding involves multiplying c by r^e.
     // Then the decryption operation performs (m^e * r^e)^d mod n
     // which equals mr mod n. The factor of r can then be removed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,9 @@
 //! Using PKCS1v15.
 //! ```
 //! use rsa::{PublicKey, RsaPrivateKey, RsaPublicKey, PaddingScheme};
-//! # /*
-//! use rand::rngs::OsRng;
-//! let mut rng = OsRng;
-//! # */
-//! # use rand::{SeedableRng, rngs::StdRng};
-//! # let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+//!
+//! let mut rng = rand::thread_rng();
+//!
 //! let bits = 2048;
 //! let private_key = RsaPrivateKey::new(&mut rng, bits).expect("failed to generate a key");
 //! let public_key = RsaPublicKey::from(&private_key);
@@ -31,12 +28,8 @@
 //! Using OAEP.
 //! ```
 //! use rsa::{PublicKey, RsaPrivateKey, RsaPublicKey, PaddingScheme};
-//! # /*
-//! use rand::rngs::OsRng;
-//! let mut rng = OsRng;
-//! # */
-//! # use rand::{SeedableRng, rngs::StdRng};
-//! # let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+//!
+//! let mut rng = rand::thread_rng();
 //!
 //! let bits = 2048;
 //! let private_key = RsaPrivateKey::new(&mut rng, bits).expect("failed to generate a key");
@@ -81,7 +74,7 @@
 //!
 //! ```
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! # #[cfg(feature = "pem")]
+//! # #[cfg(all(feature = "pem", feature = "std"))]
 //! # {
 //! use rsa::{RsaPublicKey, pkcs1::DecodeRsaPublicKey};
 //!
@@ -125,7 +118,7 @@
 //!
 //! ```
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! # #[cfg(feature = "pem")]
+//! # #[cfg(all(feature = "pem", feature = "std"))]
 //! # {
 //! use rsa::{RsaPublicKey, pkcs8::DecodePublicKey};
 //!
@@ -149,73 +142,42 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 
-#[cfg(not(feature = "alloc"))]
-compile_error!("This crate does not yet support environments without liballoc. See https://github.com/RustCrypto/RSA/issues/51.");
-
-#[cfg(feature = "alloc")]
 #[macro_use]
 extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-#[cfg(feature = "alloc")]
+pub use rand_core;
 pub use num_bigint::BigUint;
 
 /// Useful algorithms.
-#[cfg(feature = "alloc")]
 pub mod algorithms;
-
 /// Error types.
-#[cfg(feature = "alloc")]
 pub mod errors;
-
 /// Supported hash functions.
-#[cfg(feature = "alloc")]
 pub mod hash;
-
 /// Supported padding schemes.
-#[cfg(feature = "alloc")]
 pub mod padding;
 
-#[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 mod encoding;
-#[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 mod key;
-#[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 mod oaep;
-#[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 mod pkcs1v15;
-#[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 mod pss;
-#[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 mod raw;
 
-#[cfg(feature = "alloc")]
 pub use pkcs1;
-#[cfg(feature = "alloc")]
 pub use pkcs8;
 
-#[cfg(feature = "alloc")]
 pub use self::hash::Hash;
-#[cfg(feature = "alloc")]
 pub use self::key::{PublicKey, PublicKeyParts, RsaPrivateKey, RsaPublicKey};
-#[cfg(feature = "alloc")]
 pub use self::padding::PaddingScheme;
 
-// Optionally expose internals if requested via feature-flag.
-
+/// Internal raw RSA functions.
 #[cfg(not(feature = "expose-internals"))]
-#[cfg(feature = "alloc")]
 mod internals;
 
 /// Internal raw RSA functions.
-#[cfg(all(feature = "alloc", feature = "expose-internals"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+#[cfg(feature = "expose-internals")]
 #[cfg_attr(docsrs, doc(cfg(feature = "expose-internals")))]
 pub mod internals;

--- a/src/oaep.rs
+++ b/src/oaep.rs
@@ -1,7 +1,7 @@
 use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
-use rand::Rng;
+use rand_core::{CryptoRng, RngCore};
 
 use digest::DynDigest;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
@@ -18,7 +18,7 @@ const MAX_LABEL_LEN: u64 = 2_305_843_009_213_693_951;
 /// scheme from [PKCS#1 OAEP](https://datatracker.ietf.org/doc/html/rfc3447#section-7.1.1).  The message must be no longer than the
 /// length of the public modulus minus (2+ 2*hash.size()).
 #[inline]
-pub fn encrypt<R: Rng, K: PublicKey>(
+pub fn encrypt<R: RngCore + CryptoRng, K: PublicKey>(
     rng: &mut R,
     pub_key: &K,
     msg: &[u8],
@@ -45,7 +45,7 @@ pub fn encrypt<R: Rng, K: PublicKey>(
 
     let (_, payload) = em.split_at_mut(1);
     let (seed, db) = payload.split_at_mut(h_size);
-    rng.fill(seed);
+    rng.fill_bytes(seed);
 
     // Data block DB =  pHash || PS || 01 || M
     let db_len = k - h_size - 1;
@@ -71,7 +71,7 @@ pub fn encrypt<R: Rng, K: PublicKey>(
 /// forge signatures as if they had the private key. See
 /// `decrypt_session_key` for a way of solving this problem.
 #[inline]
-pub fn decrypt<R: Rng, SK: PrivateKey>(
+pub fn decrypt<R: RngCore + CryptoRng, SK: PrivateKey>(
     rng: Option<&mut R>,
     priv_key: &SK,
     ciphertext: &[u8],
@@ -95,7 +95,7 @@ pub fn decrypt<R: Rng, SK: PrivateKey>(
 /// `rng` is given. It returns one or zero in valid that indicates whether the
 /// plaintext was correctly structured.
 #[inline]
-fn decrypt_inner<R: Rng, SK: PrivateKey>(
+fn decrypt_inner<R: RngCore + CryptoRng, SK: PrivateKey>(
     rng: Option<&mut R>,
     priv_key: &SK,
     ciphertext: &[u8],

--- a/src/padding.rs
+++ b/src/padding.rs
@@ -3,7 +3,7 @@ use alloc::string::{String, ToString};
 use core::fmt;
 
 use digest::{Digest, DynDigest};
-use rand::RngCore;
+use rand_core::RngCore;
 
 use crate::hash::Hash;
 
@@ -69,17 +69,18 @@ impl PaddingScheme {
     ///
     /// # Example
     /// ```
-    ///     use sha1::Sha1;
-    ///     use sha2::Sha256;
-    ///     use rand::rngs::OsRng;
-    ///     use rsa::{BigUint, RsaPublicKey, PaddingScheme, PublicKey};
+    /// use sha1::Sha1;
+    /// use sha2::Sha256;
+    /// use rsa::{BigUint, RsaPublicKey, PaddingScheme, PublicKey};
+    /// use base64ct::{Base64, Encoding};
     ///
-    ///     let n = base64::decode("ALHgDoZmBQIx+jTmgeeHW6KsPOrj11f6CvWsiRleJlQpW77AwSZhd21ZDmlTKfaIHBSUxRUsuYNh7E2SHx8rkFVCQA2/gXkZ5GK2IUbzSTio9qXA25MWHvVxjMfKSL8ZAxZyKbrG94FLLszFAFOaiLLY8ECs7g+dXOriYtBwLUJK+lppbd+El+8ZA/zH0bk7vbqph5pIoiWggxwdq3mEz4LnrUln7r6dagSQzYErKewY8GADVpXcq5mfHC1xF2DFBub7bFjMVM5fHq7RK+pG5xjNDiYITbhLYrbVv3X0z75OvN0dY49ITWjM7xyvMWJXVJS7sJlgmCCL6RwWgP8PhcE=").unwrap();
-    ///     let e = base64::decode("AQAB").unwrap();
-    ///     
-    ///     let key = RsaPublicKey::new(BigUint::from_bytes_be(&n), BigUint::from_bytes_be(&e)).unwrap();
-    ///     let padding = PaddingScheme::new_oaep_with_mgf_hash::<Sha256, Sha1>();
-    ///     let encrypted_data = key.encrypt(&mut OsRng, padding, b"secret").unwrap();
+    /// let n = Base64::decode_vec("ALHgDoZmBQIx+jTmgeeHW6KsPOrj11f6CvWsiRleJlQpW77AwSZhd21ZDmlTKfaIHBSUxRUsuYNh7E2SHx8rkFVCQA2/gXkZ5GK2IUbzSTio9qXA25MWHvVxjMfKSL8ZAxZyKbrG94FLLszFAFOaiLLY8ECs7g+dXOriYtBwLUJK+lppbd+El+8ZA/zH0bk7vbqph5pIoiWggxwdq3mEz4LnrUln7r6dagSQzYErKewY8GADVpXcq5mfHC1xF2DFBub7bFjMVM5fHq7RK+pG5xjNDiYITbhLYrbVv3X0z75OvN0dY49ITWjM7xyvMWJXVJS7sJlgmCCL6RwWgP8PhcE=").unwrap();
+    /// let e = Base64::decode_vec("AQAB").unwrap();
+    ///
+    /// let mut rng = rand::thread_rng();
+    /// let key = RsaPublicKey::new(BigUint::from_bytes_be(&n), BigUint::from_bytes_be(&e)).unwrap();
+    /// let padding = PaddingScheme::new_oaep_with_mgf_hash::<Sha256, Sha1>();
+    /// let encrypted_data = key.encrypt(&mut rng, padding, b"secret").unwrap();
     /// ```
     pub fn new_oaep_with_mgf_hash<
         T: 'static + Digest + DynDigest,
@@ -96,17 +97,18 @@ impl PaddingScheme {
     ///
     /// # Example
     /// ```
-    ///     use sha1::Sha1;
-    ///     use sha2::Sha256;
-    ///     use rand::rngs::OsRng;
-    ///     use rsa::{BigUint, RsaPublicKey, PaddingScheme, PublicKey};
-
-    ///     let n = base64::decode("ALHgDoZmBQIx+jTmgeeHW6KsPOrj11f6CvWsiRleJlQpW77AwSZhd21ZDmlTKfaIHBSUxRUsuYNh7E2SHx8rkFVCQA2/gXkZ5GK2IUbzSTio9qXA25MWHvVxjMfKSL8ZAxZyKbrG94FLLszFAFOaiLLY8ECs7g+dXOriYtBwLUJK+lppbd+El+8ZA/zH0bk7vbqph5pIoiWggxwdq3mEz4LnrUln7r6dagSQzYErKewY8GADVpXcq5mfHC1xF2DFBub7bFjMVM5fHq7RK+pG5xjNDiYITbhLYrbVv3X0z75OvN0dY49ITWjM7xyvMWJXVJS7sJlgmCCL6RwWgP8PhcE=").unwrap();
-    ///     let e = base64::decode("AQAB").unwrap();
-    ///     
-    ///     let key = RsaPublicKey::new(BigUint::from_bytes_be(&n), BigUint::from_bytes_be(&e)).unwrap();
-    ///     let padding = PaddingScheme::new_oaep::<Sha256>();
-    ///     let encrypted_data = key.encrypt(&mut OsRng, padding, b"secret").unwrap();
+    /// use sha1::Sha1;
+    /// use sha2::Sha256;
+    /// use rsa::{BigUint, RsaPublicKey, PaddingScheme, PublicKey};
+    /// use base64ct::{Base64, Encoding};
+    ///
+    /// let n = Base64::decode_vec("ALHgDoZmBQIx+jTmgeeHW6KsPOrj11f6CvWsiRleJlQpW77AwSZhd21ZDmlTKfaIHBSUxRUsuYNh7E2SHx8rkFVCQA2/gXkZ5GK2IUbzSTio9qXA25MWHvVxjMfKSL8ZAxZyKbrG94FLLszFAFOaiLLY8ECs7g+dXOriYtBwLUJK+lppbd+El+8ZA/zH0bk7vbqph5pIoiWggxwdq3mEz4LnrUln7r6dagSQzYErKewY8GADVpXcq5mfHC1xF2DFBub7bFjMVM5fHq7RK+pG5xjNDiYITbhLYrbVv3X0z75OvN0dY49ITWjM7xyvMWJXVJS7sJlgmCCL6RwWgP8PhcE=").unwrap();
+    /// let e = Base64::decode_vec("AQAB").unwrap();
+    ///
+    /// let mut rng = rand::thread_rng();
+    /// let key = RsaPublicKey::new(BigUint::from_bytes_be(&n), BigUint::from_bytes_be(&e)).unwrap();
+    /// let padding = PaddingScheme::new_oaep::<Sha256>();
+    /// let encrypted_data = key.encrypt(&mut rng, padding, b"secret").unwrap();
     /// ```
     pub fn new_oaep<T: 'static + Digest + DynDigest>() -> Self {
         PaddingScheme::OAEP {

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 use num_bigint::BigUint;
-use rand::Rng;
+use rand_core::{CryptoRng, RngCore};
 use zeroize::Zeroize;
 
 use crate::errors::{Error, Result};
@@ -14,7 +14,7 @@ pub trait EncryptionPrimitive {
 
 pub trait DecryptionPrimitive {
     /// Do NOT use directly! Only for implementors.
-    fn raw_decryption_primitive<R: Rng>(
+    fn raw_decryption_primitive<R: RngCore + CryptoRng>(
         &self,
         rng: Option<&mut R>,
         ciphertext: &[u8],
@@ -49,7 +49,7 @@ impl<'a> EncryptionPrimitive for &'a RsaPublicKey {
 }
 
 impl DecryptionPrimitive for RsaPrivateKey {
-    fn raw_decryption_primitive<R: Rng>(
+    fn raw_decryption_primitive<R: RngCore + CryptoRng>(
         &self,
         rng: Option<&mut R>,
         ciphertext: &[u8],
@@ -70,7 +70,7 @@ impl DecryptionPrimitive for RsaPrivateKey {
 }
 
 impl<'a> DecryptionPrimitive for &'a RsaPrivateKey {
-    fn raw_decryption_primitive<R: Rng>(
+    fn raw_decryption_primitive<R: RngCore + CryptoRng>(
         &self,
         rng: Option<&mut R>,
         ciphertext: &[u8],

--- a/tests/pkcs1.rs
+++ b/tests/pkcs1.rs
@@ -1,7 +1,5 @@
 //! PKCS#1 encoding tests
 
-#![cfg(feature = "alloc")]
-
 use hex_literal::hex;
 use rsa::{
     pkcs1::{DecodeRsaPrivateKey, DecodeRsaPublicKey, EncodeRsaPrivateKey, EncodeRsaPublicKey},

--- a/tests/pkcs8.rs
+++ b/tests/pkcs8.rs
@@ -1,7 +1,5 @@
 //! PKCS#8 encoding tests
 
-#![cfg(feature = "alloc")]
-
 /// RSA-2048 PKCS#8 private key encoded as ASN.1 DER
 const RSA_2048_PRIV_DER: &[u8] = include_bytes!("examples/pkcs8/rsa2048-priv.der");
 


### PR DESCRIPTION
`rand` is still a dev-dependency and used in code examples.

Also removes dependency on `rand_xorshift`, `base64`, and `hex`. Removes the `alloc`, which was effectively useless.

Closes #115 