### PR TITLE
Remove nondeterministic tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ serde_test = "1.0.89"
 rand_xorshift = "0.3"
 rand_chacha = "0.3"
 rand = "0.8"
-rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
+rand_core = { version = "0.6", default-features = false }
 sha1 = { version = "0.10.1", default-features = false }
 sha2 = { version = "0.10.2", default-features = false }
 sha3 = { version = "0.10.1", default-features = false }

--- a/src/key.rs
+++ b/src/key.rs
@@ -625,7 +625,7 @@ mod tests {
         let m2 = internals::decrypt::<ChaCha8Rng>(None, &private_key, &c)
             .expect("unable to decrypt without blinding");
         assert_eq!(m, m2);
-        let mut rng = ChaCha8Rng::from_entropy();
+        let mut rng = ChaCha8Rng::from_seed([42; 32]);
         let m3 = internals::decrypt(Some(&mut rng), &private_key, &c)
             .expect("unable to decrypt with blinding");
         assert_eq!(m, m3);
@@ -635,7 +635,7 @@ mod tests {
         ($name:ident, $multi:expr, $size:expr) => {
             #[test]
             fn $name() {
-                let mut rng = ChaCha8Rng::from_entropy();
+                let mut rng = ChaCha8Rng::from_seed([42; 32]);
 
                 for _ in 0..10 {
                     let private_key = if $multi == 2 {
@@ -664,7 +664,7 @@ mod tests {
 
     #[test]
     fn test_impossible_keys() {
-        let mut rng = ChaCha8Rng::from_entropy();
+        let mut rng = ChaCha8Rng::from_seed([42; 32]);
         for i in 0..32 {
             let _ = RsaPrivateKey::new(&mut rng, i).is_err();
             let _ = generate_multi_prime_key(&mut rng, 3, i);
@@ -863,7 +863,7 @@ mod tests {
     }
 
     fn do_test_encrypt_decrypt_oaep<D: 'static + Digest + DynDigest>(prk: &RsaPrivateKey) {
-        let mut rng = ChaCha8Rng::from_entropy();
+        let mut rng = ChaCha8Rng::from_seed([42; 32]);
 
         let k = prk.size();
 
@@ -911,7 +911,7 @@ mod tests {
     >(
         prk: &RsaPrivateKey,
     ) {
-        let mut rng = ChaCha8Rng::from_entropy();
+        let mut rng = ChaCha8Rng::from_seed([42; 32]);
 
         let k = prk.size();
 
@@ -954,7 +954,7 @@ mod tests {
     }
     #[test]
     fn test_decrypt_oaep_invalid_hash() {
-        let mut rng = ChaCha8Rng::from_entropy();
+        let mut rng = ChaCha8Rng::from_seed([42; 32]);
         let priv_key = get_private_key();
         let pub_key: RsaPublicKey = (&priv_key).into();
         let ciphertext = pub_key

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,8 +147,8 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-pub use rand_core;
 pub use num_bigint::BigUint;
+pub use rand_core;
 
 /// Useful algorithms.
 pub mod algorithms;

--- a/src/pkcs1v15.rs
+++ b/src/pkcs1v15.rs
@@ -229,7 +229,7 @@ mod tests {
     #[test]
     fn test_non_zero_bytes() {
         for _ in 0..10 {
-            let mut rng = ChaCha8Rng::from_entropy();
+            let mut rng = ChaCha8Rng::from_seed([42; 32]);
             let mut b = vec![0u8; 512];
             non_zero_random_bytes(&mut rng, &mut b);
             for el in &b {
@@ -292,7 +292,7 @@ mod tests {
 
     #[test]
     fn test_encrypt_decrypt_pkcs1v15() {
-        let mut rng = ChaCha8Rng::from_entropy();
+        let mut rng = ChaCha8Rng::from_seed([42; 32]);
         let priv_key = get_private_key();
         let k = priv_key.size();
 
@@ -335,7 +335,7 @@ mod tests {
             assert_ne!(out, digest);
             assert_eq!(out, expected);
 
-            let mut rng = ChaCha8Rng::from_entropy();
+            let mut rng = ChaCha8Rng::from_seed([42; 32]);
             let out2 = priv_key
                 .sign_blinded(
                     &mut rng,

--- a/src/pss.rs
+++ b/src/pss.rs
@@ -283,7 +283,7 @@ mod test {
 
         for (text, sig) in &tests {
             let digest = Sha1::digest(text.as_bytes()).to_vec();
-            let rng = ChaCha8Rng::from_entropy();
+            let rng = ChaCha8Rng::from_seed([42; 32]);
             pub_key
                 .verify(PaddingScheme::new_pss::<Sha1, _>(rng), &digest, sig)
                 .expect("failed to verify");
@@ -295,7 +295,7 @@ mod test {
         let priv_key = get_private_key();
 
         let tests = ["test\n"];
-        let rng = ChaCha8Rng::from_entropy();
+        let rng = ChaCha8Rng::from_seed([42; 32]);
 
         for test in &tests {
             let digest = Sha1::digest(test.as_bytes()).to_vec();


### PR DESCRIPTION
Closes #149 

Examples (i.e. doctests) continue to use `ThreadRng`. They are intentionally kept nondeterministic since users should prefer using `ThreadRng` if possible.