### PR TITLE
Fix rustdoc warnings and add rustdoc CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - master
 
+env:
+  RUSTFLAGS: "-Dwarnings"
+  RUSTDOCFLAGS: "-Dwarnings"
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -47,6 +51,18 @@ jobs:
       - run: cargo hack test --release --feature-powerset --exclude-features nightly,getrandom,serde
       - run: cargo test --release --features getrandom
       - run: cargo test --release --features serde
+
+  doc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: RustCrypto/actions/cargo-cache@master
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+      - run: cargo doc --all-features
 
   minimal-versions:
     runs-on: ubuntu-latest

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -26,8 +26,8 @@ const EXP: u64 = 65537;
 ///
 /// Table 1 in [2] suggests maximum numbers of primes for a given size.
 ///
-/// [1] US patent 4405829 (1972, expired)
-/// [2] http://www.cacr.math.uwaterloo.ca/techreports/2006/cacr2006-16.pdf
+/// [1]: https://patents.google.com/patent/US4405829A/en
+/// [2]: https://cacr.uwaterloo.ca/techreports/2006/cacr2006-16.pdf
 pub fn generate_multi_prime_key<R: RngCore + CryptoRng>(
     rng: &mut R,
     nprimes: usize,
@@ -46,8 +46,8 @@ pub fn generate_multi_prime_key<R: RngCore + CryptoRng>(
 ///
 /// Table 1 in [2] suggests maximum numbers of primes for a given size.
 ///
-/// [1] US patent 4405829 (1972, expired)
-/// [2] http://www.cacr.math.uwaterloo.ca/techreports/2006/cacr2006-16.pdf
+/// [1]: https://patents.google.com/patent/US4405829A/en
+/// [2]: http://www.cacr.math.uwaterloo.ca/techreports/2006/cacr2006-16.pdf
 pub fn generate_multi_prime_key_with_exp<R: RngCore + CryptoRng>(
     rng: &mut R,
     nprimes: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,10 +65,10 @@
 //! [`RsaPublicKey`] as PKCS#1. Note that [`pkcs1`] is re-exported from the
 //! toplevel of the `rsa` crate:
 //!
-//! - [`pkcs1::FromRsaPrivateKey`]: decode RSA private keys from PKCS#1
-//! - [`pkcs1::FromRsaPublicKey`]: decode RSA public keys from PKCS#1
-//! - [`pkcs1::ToRsaPrivateKey`]: encode RSA private keys to PKCS#1
-//! - [`pkcs1::ToRsaPublicKey`]: encode RSA public keys to PKCS#1
+//! - [`pkcs1::DecodeRsaPrivateKey`]: decode RSA private keys from PKCS#1
+//! - [`pkcs1::DecodeRsaPublicKey`]: decode RSA public keys from PKCS#1
+//! - [`pkcs1::EncodeRsaPrivateKey`]: encode RSA private keys to PKCS#1
+//! - [`pkcs1::EncodeRsaPublicKey`]: encode RSA public keys to PKCS#1
 //!
 //! ### Example
 //!
@@ -109,10 +109,10 @@
 //! [`RsaPublicKey`] as PKCS#8. Note that [`pkcs8`] is re-exported from the
 //! toplevel of the `rsa` crate:
 //!
-//! - [`pkcs8::FromPrivateKey`]: decode private keys from PKCS#8
-//! - [`pkcs8::FromPublicKey`]: decode public keys from PKCS#8
-//! - [`pkcs8::ToPrivateKey`]: encode private keys to PKCS#8
-//! - [`pkcs8::ToPublicKey`]: encode public keys to PKCS#8
+//! - [`pkcs8::DecodePrivateKey`]: decode private keys from PKCS#8
+//! - [`pkcs8::DecodePublicKey`]: decode public keys from PKCS#8
+//! - [`pkcs8::EncodePrivateKey`]: encode private keys to PKCS#8
+//! - [`pkcs8::EncodePublicKey`]: encode public keys to PKCS#8
 //!
 //! ### Example
 //!


### PR DESCRIPTION
- Fixes some broken links to the `pkcs1`/`pkcs8` crate traits
- Fixes other rustdoc warnings
- Adds rustdoc CI job to ensure docs build without warnings