### PR TITLE
Add `RsaPrivateKey::crt_coefficient`

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -5,7 +5,6 @@
 
 use crate::{key::PublicKeyParts, BigUint, RsaPrivateKey, RsaPublicKey};
 use core::convert::{TryFrom, TryInto};
-use num_bigint::ModInverse;
 use pkcs8::{
     DecodePrivateKey, DecodePublicKey, EncodePrivateKey, EncodePublicKey, PrivateKeyDocument,
     PublicKeyDocument,
@@ -78,11 +77,9 @@ impl EncodePrivateKey for RsaPrivateKey {
         let exponent1 = Zeroizing::new((self.d() % (&self.primes[0] - 1u8)).to_bytes_be());
         let exponent2 = Zeroizing::new((self.d() % (&self.primes[1] - 1u8)).to_bytes_be());
         let coefficient = Zeroizing::new(
-            (&self.primes[1])
-                .mod_inverse(&self.primes[0])
+            self.crt_coefficient()
                 .ok_or(pkcs1::Error::Crypto)?
-                .to_bytes_be()
-                .1,
+                .to_bytes_be(),
         );
 
         let private_key = pkcs1::RsaPrivateKey {

--- a/src/key.rs
+++ b/src/key.rs
@@ -396,6 +396,11 @@ impl RsaPrivateKey {
         &self.primes
     }
 
+    /// Compute CRT coefficient: `(1/q) mod p`.
+    pub fn crt_coefficient(&self) -> Option<BigUint> {
+        (&self.primes[1]).mod_inverse(&self.primes[0])?.to_biguint()
+    }
+
     /// Performs basic sanity checks on the key.
     /// Returns `Ok(())` if everything is good, otherwise an approriate error.
     pub fn validate(&self) -> Result<()> {


### PR DESCRIPTION
This method is useful for key serialization formats and is internally useful within the context of the PKCS#1/PKCS#8 implementations.

Externally I'm working on adding support to the `ssh-key` crate. I could implement this same thing by pulling in `num_bigint_dig::ModInverse`, it'd be a lot easier if this purpose-dedicated method were available.