### PR TITLE
Bump `pkcs1` => 0.4, `pkcs8` => 0.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/RustCrypto/RSA"
 keywords = ["rsa", "encryption", "security", "crypto"]
 categories = ["cryptography"]
 readme = "README.md"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
 num-bigint = { version = "0.8.1", features = ["i128", "u64_digit", "prime", "zeroize"], default-features = false, package = "num-bigint-dig" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ rand_core = { version = "0.6", default-features = false }
 byteorder = { version = "1.3.1", default-features = false }
 subtle = { version = "2.1.1", default-features = false }
 digest = { version = "0.10.0", default-features = false, features = ["alloc"] }
-pkcs1 = { version = "0.3.3", default-features = false, features = ["pkcs8", "alloc"] }
-pkcs8 = { version = "0.8", default-features = false, features = ["alloc"] }
+pkcs1 = { version = "0.4", default-features = false, features = ["pkcs8", "alloc"] }
+pkcs8 = { version = "0.9", default-features = false, features = ["alloc"] }
 zeroize = { version = "1", features = ["alloc"] }
 
 # Temporary workaround until https://github.com/dignifiedquire/num-bigint/pull/42 lands

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![crates.io][crate-image]][crate-link]
 [![Documentation][doc-image]][doc-link]
 [![Build Status][build-image]][build-link]
-![minimum rustc 1.56][msrv-image]
+![minimum rustc 1.57][msrv-image]
 [![Project Chat][chat-image]][chat-link]
 [![dependency status][deps-image]][deps-link]
 
@@ -70,7 +70,7 @@ There will be three phases before `1.0` 🚢 can be released.
 
 ## Minimum Supported Rust Version (MSRV)
 
-All crates in this repository support Rust 1.56 or higher. In future
+All crates in this repository support Rust 1.57 or higher. In future
 minimally supported version of Rust can be changed, but it will be done with
 a minor version bump.
 
@@ -97,7 +97,7 @@ dual licensed as above, without any additional terms or conditions.
 [doc-link]: https://docs.rs/rsa
 [build-image]: https://github.com/rustcrypto/RSA/workflows/CI/badge.svg
 [build-link]: https://github.com/RustCrypto/RSA/actions?query=workflow%3ACI+branch%3Amaster
-[msrv-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.57+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260047-RSA
 [deps-image]: https://deps.rs/repo/github/RustCrypto/RSA/status.svg

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -5,9 +5,9 @@
 
 use crate::{key::PublicKeyParts, BigUint, RsaPrivateKey, RsaPublicKey};
 use core::convert::{TryFrom, TryInto};
+use pkcs1::der::Encode;
 use pkcs8::{
-    DecodePrivateKey, DecodePublicKey, EncodePrivateKey, EncodePublicKey, PrivateKeyDocument,
-    PublicKeyDocument,
+    DecodePrivateKey, DecodePublicKey, Document, EncodePrivateKey, EncodePublicKey, SecretDocument,
 };
 use zeroize::Zeroizing;
 
@@ -56,14 +56,14 @@ impl TryFrom<pkcs8::SubjectPublicKeyInfo<'_>> for RsaPublicKey {
         let pkcs1_key = pkcs1::RsaPublicKey::try_from(spki.subject_public_key)?;
         let n = BigUint::from_bytes_be(pkcs1_key.modulus.as_bytes());
         let e = BigUint::from_bytes_be(pkcs1_key.public_exponent.as_bytes());
-        Ok(RsaPublicKey::new(n, e).map_err(|_| pkcs8::spki::Error::KeyMalformed)?)
+        RsaPublicKey::new(n, e).map_err(|_| pkcs8::spki::Error::KeyMalformed)
     }
 }
 
 impl DecodePublicKey for RsaPublicKey {}
 
 impl EncodePrivateKey for RsaPrivateKey {
-    fn to_pkcs8_der(&self) -> pkcs8::Result<PrivateKeyDocument> {
+    fn to_pkcs8_der(&self) -> pkcs8::Result<SecretDocument> {
         // Check if the key is multi prime
         if self.primes.len() > 2 {
             return Err(pkcs1::Error::Version.into());
@@ -83,32 +83,32 @@ impl EncodePrivateKey for RsaPrivateKey {
         );
 
         let private_key = pkcs1::RsaPrivateKey {
-            modulus: pkcs1::UIntBytes::new(&modulus)?,
-            public_exponent: pkcs1::UIntBytes::new(&public_exponent)?,
-            private_exponent: pkcs1::UIntBytes::new(&private_exponent)?,
-            prime1: pkcs1::UIntBytes::new(&prime1)?,
-            prime2: pkcs1::UIntBytes::new(&prime2)?,
-            exponent1: pkcs1::UIntBytes::new(&exponent1)?,
-            exponent2: pkcs1::UIntBytes::new(&exponent2)?,
-            coefficient: pkcs1::UIntBytes::new(&coefficient)?,
+            modulus: pkcs1::UIntRef::new(&modulus)?,
+            public_exponent: pkcs1::UIntRef::new(&public_exponent)?,
+            private_exponent: pkcs1::UIntRef::new(&private_exponent)?,
+            prime1: pkcs1::UIntRef::new(&prime1)?,
+            prime2: pkcs1::UIntRef::new(&prime2)?,
+            exponent1: pkcs1::UIntRef::new(&exponent1)?,
+            exponent2: pkcs1::UIntRef::new(&exponent2)?,
+            coefficient: pkcs1::UIntRef::new(&coefficient)?,
             other_prime_infos: None,
         }
-        .to_der()?;
+        .to_vec()?;
 
-        pkcs8::PrivateKeyInfo::new(pkcs1::ALGORITHM_ID, private_key.as_ref()).to_der()
+        pkcs8::PrivateKeyInfo::new(pkcs1::ALGORITHM_ID, private_key.as_ref()).try_into()
     }
 }
 
 impl EncodePublicKey for RsaPublicKey {
-    fn to_public_key_der(&self) -> pkcs8::spki::Result<PublicKeyDocument> {
+    fn to_public_key_der(&self) -> pkcs8::spki::Result<Document> {
         let modulus = self.n().to_bytes_be();
         let public_exponent = self.e().to_bytes_be();
 
         let subject_public_key = pkcs1::RsaPublicKey {
-            modulus: pkcs1::UIntBytes::new(&modulus)?,
-            public_exponent: pkcs1::UIntBytes::new(&public_exponent)?,
+            modulus: pkcs1::UIntRef::new(&modulus)?,
+            public_exponent: pkcs1::UIntRef::new(&public_exponent)?,
         }
-        .to_der()?;
+        .to_vec()?;
 
         pkcs8::SubjectPublicKeyInfo {
             algorithm: pkcs1::ALGORITHM_ID,

--- a/tests/pkcs1.rs
+++ b/tests/pkcs1.rs
@@ -90,14 +90,14 @@ fn decode_rsa4096_pub_der() {
 fn encode_rsa2048_priv_der() {
     let key = RsaPrivateKey::from_pkcs1_der(RSA_2048_PRIV_DER).unwrap();
     let der = key.to_pkcs1_der().unwrap();
-    assert_eq!(der.as_ref(), RSA_2048_PRIV_DER)
+    assert_eq!(der.as_bytes(), RSA_2048_PRIV_DER)
 }
 
 #[test]
 fn encode_rsa4096_priv_der() {
     let key = RsaPrivateKey::from_pkcs1_der(RSA_4096_PRIV_DER).unwrap();
     let der = key.to_pkcs1_der().unwrap();
-    assert_eq!(der.as_ref(), RSA_4096_PRIV_DER)
+    assert_eq!(der.as_bytes(), RSA_4096_PRIV_DER)
 }
 
 #[test]

--- a/tests/pkcs8.rs
+++ b/tests/pkcs8.rs
@@ -45,7 +45,7 @@ fn decode_rsa2048_pub_der() {
 fn encode_rsa2048_priv_der() {
     let key = RsaPrivateKey::from_pkcs8_der(RSA_2048_PRIV_DER).unwrap();
     let der = key.to_pkcs8_der().unwrap();
-    assert_eq!(der.as_ref(), RSA_2048_PRIV_DER)
+    assert_eq!(der.as_bytes(), RSA_2048_PRIV_DER)
 }
 
 #[test]


### PR DESCRIPTION
This updates both the `pkcs1` and `pkcs8` crates to their latest version.
It mainly involves renaming `PublicKeyDocument` => `Document`, `PrivateKeyDocument` => `SecretDocument` and `UIntBytes` => `UIntRef`.