### PR TITLE
Fix bug on pkcs1.rs

### DIFF
--- a/tests/pkcs1.rs
+++ b/tests/pkcs1.rs
@@ -169,7 +169,8 @@ fn decode_rsa4096_pub_pem() {
 fn encode_rsa2048_priv_pem() {
     let key = RsaPrivateKey::from_pkcs1_pem(RSA_2048_PRIV_PEM).unwrap();
     let pem = key.to_pkcs1_pem(Default::default()).unwrap();
-    assert_eq!(&*pem, RSA_2048_PRIV_PEM)
+    let c = pem.replace("\r","");
+    assert_eq!(c, RSA_2048_PRIV_PEM)
 }
 
 #[test]
@@ -177,7 +178,8 @@ fn encode_rsa2048_priv_pem() {
 fn encode_rsa4096_priv_pem() {
     let key = RsaPrivateKey::from_pkcs1_pem(RSA_4096_PRIV_PEM).unwrap();
     let pem = key.to_pkcs1_pem(Default::default()).unwrap();
-    assert_eq!(&*pem, RSA_4096_PRIV_PEM)
+    let c = pem.replace("\r","");
+    assert_eq!(c, RSA_4096_PRIV_PEM)
 }
 
 #[test]
@@ -185,7 +187,8 @@ fn encode_rsa4096_priv_pem() {
 fn encode_rsa2048_pub_pem() {
     let key = RsaPublicKey::from_pkcs1_pem(RSA_2048_PUB_PEM).unwrap();
     let pem = key.to_pkcs1_pem(Default::default()).unwrap();
-    assert_eq!(&*pem, RSA_2048_PUB_PEM)
+    let c = pem.replace("\r","");
+    assert_eq!(c, RSA_2048_PUB_PEM)
 }
 
 #[test]
@@ -193,5 +196,6 @@ fn encode_rsa2048_pub_pem() {
 fn encode_rsa4096_pub_pem() {
     let key = RsaPublicKey::from_pkcs1_pem(RSA_4096_PUB_PEM).unwrap();
     let pem = key.to_pkcs1_pem(Default::default()).unwrap();
-    assert_eq!(&*pem, RSA_4096_PUB_PEM)
+    let c = pem.replace("\r","");
+    assert_eq!(c, RSA_4096_PUB_PEM)
 }

--- a/tests/pkcs8.rs
+++ b/tests/pkcs8.rs
@@ -83,7 +83,8 @@ fn decode_rsa2048_pub_pem() {
 fn encode_rsa2048_priv_pem() {
     let key = RsaPrivateKey::from_pkcs8_pem(RSA_2048_PRIV_PEM).unwrap();
     let pem = key.to_pkcs8_pem(Default::default()).unwrap();
-    assert_eq!(&*pem, RSA_2048_PRIV_PEM)
+    let c = pem.replace("\r","");
+    assert_eq!(c, RSA_2048_PRIV_PEM)
 }
 
 #[test]
@@ -91,5 +92,6 @@ fn encode_rsa2048_priv_pem() {
 fn encode_rsa2048_pub_pem() {
     let key = RsaPublicKey::from_public_key_pem(RSA_2048_PUB_PEM).unwrap();
     let pem = key.to_public_key_pem(Default::default()).unwrap();
-    assert_eq!(&*pem, RSA_2048_PUB_PEM)
+    let c = pem.replace("\r","");
+    assert_eq!(c, RSA_2048_PUB_PEM)
 }


### PR DESCRIPTION
    	encode_rsa2048_priv_pem
   		encode_rsa4096_priv_pem
   		encode_rsa2048_pub_pem
   		encode_rsa4096_pub_pem
   pkcs8.rs
   		encode_rsa2048_priv_pem
   		encode_rsa2048_pub_pem
   when running in windows-gnu adding the '\r' in string