### PR TITLE
rsa: pass unhashed data to SignerKey/VerifierKey

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,17 +58,16 @@
 //!
 //! let bits = 2048;
 //! let private_key = RsaPrivateKey::new(&mut rng, bits).expect("failed to generate a key");
-//! let signing_key = SigningKey::new_with_hash(private_key, Hash::SHA2_256);
+//! let signing_key = SigningKey::new_with_hash(private_key, Hash::SHA2_256, Box::new(Sha256::new()));
 //! let verifying_key: VerifyingKey = (&signing_key).into();
 //!
 //! // Sign
 //! let data = b"hello world";
-//! let digest = Sha256::digest(data).to_vec();
-//! let signature = signing_key.sign_with_rng(&mut rng, &digest);
+//! let signature = signing_key.sign_with_rng(&mut rng, data);
 //! assert_ne!(signature.as_bytes(), data);
 //!
 //! // Verify
-//! verifying_key.verify(&digest, &signature).expect("failed to verify");
+//! verifying_key.verify(data, &signature).expect("failed to verify");
 //! ```
 //!
 //! Using PSS signatures
@@ -87,12 +86,11 @@
 //!
 //! // Sign
 //! let data = b"hello world";
-//! let digest = Sha256::digest(data).to_vec();
-//! let signature = signing_key.sign_with_rng(&mut rng, &digest);
+//! let signature = signing_key.sign_with_rng(&mut rng, data);
 //! assert_ne!(signature.as_bytes(), data);
 //!
 //! // Verify
-//! verifying_key.verify(&digest, &signature).expect("failed to verify");
+//! verifying_key.verify(data, &signature).expect("failed to verify");
 //! ```
 //!
 //! ## PKCS#1 RSA Key Encoding


### PR DESCRIPTION
Quoting Tony Arcieri:

> Generally working directly with raw digests is an antipattern. It's
> much less of a problem with RSA than it is with e.g. ECDSA or Schnorr
> though, where it can lead to existential forgeries.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>