### PR TITLE
Fix PKCS#1/PKCS#8 line endings on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+tests/examples/pkcs1/*.pem text eol=lf
+tests/examples/pkcs8/*.pem text eol=lf

--- a/tests/pkcs1.rs
+++ b/tests/pkcs1.rs
@@ -6,6 +6,9 @@ use rsa::{
     PublicKeyParts, RsaPrivateKey, RsaPublicKey,
 };
 
+#[cfg(feature = "pem")]
+use rsa::pkcs1::LineEnding;
+
 /// RSA-2048 PKCS#1 private key encoded as ASN.1 DER.
 ///
 /// Note: this key is extracted from the corresponding `rsa2048-priv.der`
@@ -168,7 +171,7 @@ fn decode_rsa4096_pub_pem() {
 #[cfg(feature = "pem")]
 fn encode_rsa2048_priv_pem() {
     let key = RsaPrivateKey::from_pkcs1_pem(RSA_2048_PRIV_PEM).unwrap();
-    let pem = key.to_pkcs1_pem(Default::default()).unwrap();
+    let pem = key.to_pkcs1_pem(LineEnding::LF).unwrap();
     assert_eq!(&*pem, RSA_2048_PRIV_PEM)
 }
 
@@ -176,7 +179,7 @@ fn encode_rsa2048_priv_pem() {
 #[cfg(feature = "pem")]
 fn encode_rsa4096_priv_pem() {
     let key = RsaPrivateKey::from_pkcs1_pem(RSA_4096_PRIV_PEM).unwrap();
-    let pem = key.to_pkcs1_pem(Default::default()).unwrap();
+    let pem = key.to_pkcs1_pem(LineEnding::LF).unwrap();
     assert_eq!(&*pem, RSA_4096_PRIV_PEM)
 }
 
@@ -184,7 +187,7 @@ fn encode_rsa4096_priv_pem() {
 #[cfg(feature = "pem")]
 fn encode_rsa2048_pub_pem() {
     let key = RsaPublicKey::from_pkcs1_pem(RSA_2048_PUB_PEM).unwrap();
-    let pem = key.to_pkcs1_pem(Default::default()).unwrap();
+    let pem = key.to_pkcs1_pem(LineEnding::LF).unwrap();
     assert_eq!(&*pem, RSA_2048_PUB_PEM)
 }
 
@@ -192,6 +195,6 @@ fn encode_rsa2048_pub_pem() {
 #[cfg(feature = "pem")]
 fn encode_rsa4096_pub_pem() {
     let key = RsaPublicKey::from_pkcs1_pem(RSA_4096_PUB_PEM).unwrap();
-    let pem = key.to_pkcs1_pem(Default::default()).unwrap();
+    let pem = key.to_pkcs1_pem(LineEnding::LF).unwrap();
     assert_eq!(&*pem, RSA_4096_PUB_PEM)
 }

--- a/tests/pkcs8.rs
+++ b/tests/pkcs8.rs
@@ -20,6 +20,9 @@ use rsa::{
     PublicKeyParts, RsaPrivateKey, RsaPublicKey,
 };
 
+#[cfg(feature = "pem")]
+use rsa::pkcs8::LineEnding;
+
 #[test]
 fn decode_rsa2048_priv_der() {
     let key = RsaPrivateKey::from_pkcs8_der(RSA_2048_PRIV_DER).unwrap();
@@ -82,7 +85,7 @@ fn decode_rsa2048_pub_pem() {
 #[cfg(feature = "pem")]
 fn encode_rsa2048_priv_pem() {
     let key = RsaPrivateKey::from_pkcs8_pem(RSA_2048_PRIV_PEM).unwrap();
-    let pem = key.to_pkcs8_pem(Default::default()).unwrap();
+    let pem = key.to_pkcs8_pem(LineEnding::LF).unwrap();
     assert_eq!(&*pem, RSA_2048_PRIV_PEM)
 }
 
@@ -90,6 +93,6 @@ fn encode_rsa2048_priv_pem() {
 #[cfg(feature = "pem")]
 fn encode_rsa2048_pub_pem() {
     let key = RsaPublicKey::from_public_key_pem(RSA_2048_PUB_PEM).unwrap();
-    let pem = key.to_public_key_pem(Default::default()).unwrap();
+    let pem = key.to_public_key_pem(LineEnding::LF).unwrap();
     assert_eq!(&*pem, RSA_2048_PUB_PEM)
 }


### PR DESCRIPTION
The checked-in files use Unix-style line endings, so use `LineEnding::LF` in tests, rather than `Default::default` (which uses OS-specific line endings.

Closes #175.