### PR TITLE
Allow dereferencing Signature types

### DIFF
--- a/src/pkcs1v15.rs
+++ b/src/pkcs1v15.rs
@@ -2,6 +2,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::fmt::{Debug, Display, Formatter, LowerHex, UpperHex};
 use core::marker::PhantomData;
+use core::ops::Deref;
 use digest::Digest;
 use rand_core::{CryptoRng, RngCore};
 use signature::{
@@ -37,6 +38,14 @@ impl signature::Signature for Signature {
 impl From<Vec<u8>> for Signature {
     fn from(bytes: Vec<u8>) -> Self {
         Self { bytes }
+    }
+}
+
+impl Deref for Signature {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_bytes()
     }
 }
 

--- a/src/pss.rs
+++ b/src/pss.rs
@@ -3,6 +3,7 @@ use alloc::vec::Vec;
 
 use core::fmt::{Debug, Display, Formatter, LowerHex, UpperHex};
 use core::marker::PhantomData;
+use core::ops::Deref;
 use digest::{Digest, DynDigest, FixedOutputReset};
 use rand_core::{CryptoRng, RngCore};
 use signature::{
@@ -35,6 +36,14 @@ impl signature::Signature for Signature {
 impl From<Vec<u8>> for Signature {
     fn from(bytes: Vec<u8>) -> Self {
         Self { bytes }
+    }
+}
+
+impl Deref for Signature {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_bytes()
     }
 }
 


### PR DESCRIPTION
Implement Deref<Target = [u8]> for the Signature types to allow automatically dereferencing Signature as byte slices.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>