### PR TITLE
Drop reference boilerplate code

### DIFF
--- a/src/internals.rs
+++ b/src/internals.rs
@@ -168,7 +168,7 @@ pub fn blind<R: RngCore + CryptoRng, K: PublicKeyParts>(
 }
 
 /// Given an m and and unblinding factor, unblind the m.
-pub fn unblind(key: impl PublicKeyParts, m: &BigUint, unblinder: &BigUint) -> BigUint {
+pub fn unblind(key: &impl PublicKeyParts, m: &BigUint, unblinder: &BigUint) -> BigUint {
     (m * unblinder) % key.n()
 }
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -251,33 +251,6 @@ impl RsaPublicKey {
     }
 }
 
-impl<'a> PublicKeyParts for &'a RsaPublicKey {
-    /// Returns the modulus of the key.
-    fn n(&self) -> &BigUint {
-        &self.n
-    }
-
-    /// Returns the public exponent of the key.
-    fn e(&self) -> &BigUint {
-        &self.e
-    }
-}
-
-impl<'a> PublicKey for &'a RsaPublicKey {
-    fn encrypt<R: RngCore + CryptoRng>(
-        &self,
-        rng: &mut R,
-        padding: PaddingScheme,
-        msg: &[u8],
-    ) -> Result<Vec<u8>> {
-        (*self).encrypt(rng, padding, msg)
-    }
-
-    fn verify(&self, padding: PaddingScheme, hashed: &[u8], sig: &[u8]) -> Result<()> {
-        (*self).verify(padding, hashed, sig)
-    }
-}
-
 impl PublicKeyParts for RsaPrivateKey {
     fn n(&self) -> &BigUint {
         &self.n
@@ -289,18 +262,6 @@ impl PublicKeyParts for RsaPrivateKey {
 }
 
 impl PrivateKey for RsaPrivateKey {}
-
-impl<'a> PublicKeyParts for &'a RsaPrivateKey {
-    fn n(&self) -> &BigUint {
-        &self.n
-    }
-
-    fn e(&self) -> &BigUint {
-        &self.e
-    }
-}
-
-impl<'a> PrivateKey for &'a RsaPrivateKey {}
 
 impl RsaPrivateKey {
     /// Generate a new Rsa key pair of the given bit size using the passed in `rng`.

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -42,12 +42,6 @@ impl EncryptionPrimitive for RsaPublicKey {
     }
 }
 
-impl<'a> EncryptionPrimitive for &'a RsaPublicKey {
-    fn raw_encryption_primitive(&self, plaintext: &[u8], pad_size: usize) -> Result<Vec<u8>> {
-        (*self).raw_encryption_primitive(plaintext, pad_size)
-    }
-}
-
 impl DecryptionPrimitive for RsaPrivateKey {
     fn raw_decryption_primitive<R: RngCore + CryptoRng>(
         &self,
@@ -66,16 +60,5 @@ impl DecryptionPrimitive for RsaPrivateKey {
         m_bytes.zeroize();
 
         Ok(plaintext)
-    }
-}
-
-impl<'a> DecryptionPrimitive for &'a RsaPrivateKey {
-    fn raw_decryption_primitive<R: RngCore + CryptoRng>(
-        &self,
-        rng: Option<&mut R>,
-        ciphertext: &[u8],
-        pad_size: usize,
-    ) -> Result<Vec<u8>> {
-        (*self).raw_decryption_primitive(rng, ciphertext, pad_size)
     }
 }


### PR DESCRIPTION
Drop boilerplate code which implements traits for references to key types. The code can use references directly.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>