### PR TITLE
Remove implicit key cloning from the From implementation

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -156,16 +156,7 @@ impl Zeroize for CRTValue {
 
 impl From<RsaPrivateKey> for RsaPublicKey {
     fn from(private_key: RsaPrivateKey) -> Self {
-        (&private_key).into()
-    }
-}
-
-impl From<&RsaPrivateKey> for RsaPublicKey {
-    fn from(private_key: &RsaPrivateKey) -> Self {
-        let n = private_key.n.clone();
-        let e = private_key.e.clone();
-
-        RsaPublicKey { n, e }
+        private_key.into()
     }
 }
 


### PR DESCRIPTION
Remove the implicit key cloning implemented as 'From<&RsaPrivateKey> for RsaPublicKey'. Replace that with excplicitly cloning the RsaPublicKey.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>