### PR TITLE
Implement Keypair trait for the RSA keys

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -3,7 +3,7 @@
 //! Note: PKCS#1 support is achieved through a blanket impl of the
 //! `pkcs1` crate's traits for types which impl the `pkcs8` crate's traits.
 
-use crate::{key::PublicKeyParts, BigUint, RsaPrivateKey, RsaPublicKey};
+use crate::{BigUint, PrivateKeyParts, PublicKeyParts, RsaPrivateKey, RsaPublicKey};
 use core::convert::{TryFrom, TryInto};
 use pkcs1::der::Encode;
 use pkcs8::{
@@ -65,17 +65,17 @@ impl DecodePublicKey for RsaPublicKey {}
 impl EncodePrivateKey for RsaPrivateKey {
     fn to_pkcs8_der(&self) -> pkcs8::Result<SecretDocument> {
         // Check if the key is multi prime
-        if self.primes.len() > 2 {
+        if self.primes().len() > 2 {
             return Err(pkcs1::Error::Version.into());
         }
 
         let modulus = self.n().to_bytes_be();
         let public_exponent = self.e().to_bytes_be();
         let private_exponent = Zeroizing::new(self.d().to_bytes_be());
-        let prime1 = Zeroizing::new(self.primes[0].to_bytes_be());
-        let prime2 = Zeroizing::new(self.primes[1].to_bytes_be());
-        let exponent1 = Zeroizing::new((self.d() % (&self.primes[0] - 1u8)).to_bytes_be());
-        let exponent2 = Zeroizing::new((self.d() % (&self.primes[1] - 1u8)).to_bytes_be());
+        let prime1 = Zeroizing::new(self.primes()[0].to_bytes_be());
+        let prime2 = Zeroizing::new(self.primes()[1].to_bytes_be());
+        let exponent1 = Zeroizing::new((self.d() % (&self.primes()[0] - 1u8)).to_bytes_be());
+        let exponent2 = Zeroizing::new((self.d() % (&self.primes()[1] - 1u8)).to_bytes_be());
         let coefficient = Zeroizing::new(
             self.crt_coefficient()
                 .ok_or(pkcs1::Error::Crypto)?

--- a/src/internals.rs
+++ b/src/internals.rs
@@ -7,7 +7,7 @@ use rand_core::{CryptoRng, RngCore};
 use zeroize::Zeroize;
 
 use crate::errors::{Error, Result};
-use crate::key::{PrivateKeyPartsInt, PublicKeyParts};
+use crate::keyparts::{PrivateKeyPartsInt, PublicKeyParts};
 
 /// Raw RSA encryption of m with the public key. No padding is performed.
 #[inline]

--- a/src/internals.rs
+++ b/src/internals.rs
@@ -18,7 +18,7 @@ pub fn encrypt<K: PublicKeyParts>(key: &K, m: &BigUint) -> BigUint {
 /// Performs raw RSA decryption with no padding, resulting in a plaintext `BigUint`.
 /// Peforms RSA blinding if an `Rng` is passed.
 #[inline]
-pub fn decrypt<R: RngCore + CryptoRng>(
+pub(crate) fn decrypt<R: RngCore + CryptoRng>(
     mut rng: Option<&mut R>,
     priv_key: &RsaPrivateKey,
     c: &BigUint,
@@ -127,7 +127,7 @@ pub fn decrypt_and_check<R: RngCore + CryptoRng>(
 }
 
 /// Returns the blinded c, along with the unblinding factor.
-pub fn blind<R: RngCore + CryptoRng, K: PublicKeyParts>(
+fn blind<R: RngCore + CryptoRng, K: PublicKeyParts>(
     rng: &mut R,
     key: &K,
     c: &BigUint,
@@ -168,7 +168,7 @@ pub fn blind<R: RngCore + CryptoRng, K: PublicKeyParts>(
 }
 
 /// Given an m and and unblinding factor, unblind the m.
-pub fn unblind(key: &impl PublicKeyParts, m: &BigUint, unblinder: &BigUint) -> BigUint {
+fn unblind(key: &impl PublicKeyParts, m: &BigUint, unblinder: &BigUint) -> BigUint {
     (m * unblinder) % key.n()
 }
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,8 +1,7 @@
 use alloc::vec::Vec;
 use core::ops::Deref;
 use num_bigint::traits::ModInverse;
-use num_bigint::Sign::Plus;
-use num_bigint::{BigInt, BigUint};
+use num_bigint::BigUint;
 use num_traits::{One, ToPrimitive};
 use rand_core::{CryptoRng, RngCore};
 #[cfg(feature = "serde")]
@@ -13,42 +12,19 @@ use serde_crate::de::{
 use serde_crate::ser::{Serialize as SerSerialize, SerializeStruct, Serializer};
 #[cfg(feature = "serde")]
 use serde_crate::{Deserialize, Serialize};
-use zeroize::Zeroize;
 
 use crate::algorithms::{generate_multi_prime_key, generate_multi_prime_key_with_exp};
 use crate::dummy_rng::DummyRng;
 use crate::errors::{Error, Result};
 
+use crate::keyparts::{
+    PrecomputedValues, PrivateKeyParts, PrivateKeyPartsInt, PublicKeyParts, RsaPrivateKeyComponents,
+};
 use crate::padding::PaddingScheme;
 use crate::raw::{DecryptionPrimitive, EncryptionPrimitive};
 use crate::{oaep, pkcs1v15, pss};
 
-pub trait PublicKeyParts {
-    /// Returns the modulus of the key.
-    fn n(&self) -> &BigUint;
-
-    /// Returns the public exponent of the key.
-    fn e(&self) -> &BigUint;
-
-    /// Returns the modulus size in bytes. Raw signatures and ciphertexts for
-    /// or by this public key will have the same size.
-    fn size(&self) -> usize {
-        (self.n().bits() + 7) / 8
-    }
-}
-
 pub trait PrivateKey: DecryptionPrimitive + PublicKeyParts {}
-
-pub trait PrivateKeyParts {
-    /// Returns the private exponent of the key.
-    fn d(&self) -> &BigUint;
-    /// Returns the prime factors.
-    fn primes(&self) -> &[BigUint];
-}
-
-pub(crate) trait PrivateKeyPartsInt: PrivateKeyParts {
-    fn precomputed(&self) -> &Option<PrecomputedValues>;
-}
 
 impl PrivateKeyParts for RsaPrivateKey {
     /// Returns the private exponent of the key.
@@ -77,130 +53,6 @@ impl PrivateKeyPartsInt for RsaPrivateKey {
 pub struct RsaPublicKey {
     n: BigUint,
     e: BigUint,
-}
-
-/// Internal representation of the public part of an RSA key.
-#[derive(Debug, Clone)]
-#[cfg_attr(
-    feature = "serde",
-    derive(Serialize, Deserialize),
-    serde(crate = "serde_crate")
-)]
-pub(crate) struct RsaPrivateKeyComponents {
-    /// Private exponent
-    d: BigUint,
-    /// Prime factors of N, contains >= 2 elements.
-    primes: Vec<BigUint>,
-    /// precomputed values to speed up private operations
-    #[cfg_attr(feature = "serde", serde(skip))]
-    precomputed: Option<PrecomputedValues>,
-}
-
-impl RsaPrivateKeyComponents {
-    pub fn new(d: BigUint, primes: Vec<BigUint>) -> RsaPrivateKeyComponents {
-        let mut k = RsaPrivateKeyComponents {
-            d,
-            primes,
-            precomputed: None,
-        };
-
-        let _ = k.precompute();
-
-        k
-    }
-    /// Performs some calculations to speed up private key operations.
-    pub fn precompute(&mut self) -> Result<()> {
-        if self.precomputed.is_some() {
-            return Ok(());
-        }
-
-        let dp = &self.d % (&self.primes[0] - BigUint::one());
-        let dq = &self.d % (&self.primes[1] - BigUint::one());
-        let qinv = self.primes[1]
-            .clone()
-            .mod_inverse(&self.primes[0])
-            .ok_or(Error::InvalidPrime)?;
-
-        let mut r: BigUint = &self.primes[0] * &self.primes[1];
-        let crt_values: Vec<CRTValue> = {
-            let mut values = Vec::with_capacity(self.primes.len() - 2);
-            for prime in &self.primes[2..] {
-                let res = CRTValue {
-                    exp: BigInt::from_biguint(Plus, &self.d % (prime - BigUint::one())),
-                    r: BigInt::from_biguint(Plus, r.clone()),
-                    coeff: BigInt::from_biguint(
-                        Plus,
-                        r.clone()
-                            .mod_inverse(prime)
-                            .ok_or(Error::InvalidCoefficient)?
-                            .to_biguint()
-                            .unwrap(),
-                    ),
-                };
-                r *= prime;
-
-                values.push(res);
-            }
-            values
-        };
-
-        self.precomputed = Some(PrecomputedValues {
-            dp,
-            dq,
-            qinv,
-            crt_values,
-        });
-
-        Ok(())
-    }
-
-    /// Clears precomputed values by setting to None
-    pub fn clear_precomputed(&mut self) {
-        self.precomputed = None;
-    }
-}
-
-impl PartialEq for RsaPrivateKeyComponents {
-    #[inline]
-    fn eq(&self, other: &RsaPrivateKeyComponents) -> bool {
-        self.d == other.d && self.primes == other.primes
-    }
-}
-
-impl Zeroize for RsaPrivateKeyComponents {
-    fn zeroize(&mut self) {
-        self.d.zeroize();
-        for prime in self.primes.iter_mut() {
-            prime.zeroize();
-        }
-        self.primes.clear();
-        if self.precomputed.is_some() {
-            self.precomputed.take().unwrap().zeroize();
-        }
-    }
-}
-
-impl Drop for RsaPrivateKeyComponents {
-    fn drop(&mut self) {
-        self.zeroize();
-    }
-}
-
-impl PrivateKeyParts for RsaPrivateKeyComponents {
-    /// Returns the private exponent of the key.
-    fn d(&self) -> &BigUint {
-        &self.d
-    }
-    /// Returns the prime factors.
-    fn primes(&self) -> &[BigUint] {
-        &self.primes
-    }
-}
-
-impl PrivateKeyPartsInt for RsaPrivateKeyComponents {
-    fn precomputed(&self) -> &Option<PrecomputedValues> {
-        &self.precomputed
-    }
 }
 
 /// Represents a whole RSA key, public and private parts.
@@ -333,59 +185,6 @@ impl Deref for RsaPrivateKey {
     type Target = RsaPublicKey;
     fn deref(&self) -> &RsaPublicKey {
         &self.pubkey_components
-    }
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct PrecomputedValues {
-    /// D mod (P-1)
-    pub(crate) dp: BigUint,
-    /// D mod (Q-1)
-    pub(crate) dq: BigUint,
-    /// Q^-1 mod P
-    pub(crate) qinv: BigInt,
-
-    /// CRTValues is used for the 3rd and subsequent primes. Due to a
-    /// historical accident, the CRT for the first two primes is handled
-    /// differently in PKCS#1 and interoperability is sufficiently
-    /// important that we mirror this.
-    pub(crate) crt_values: Vec<CRTValue>,
-}
-
-impl Zeroize for PrecomputedValues {
-    fn zeroize(&mut self) {
-        self.dp.zeroize();
-        self.dq.zeroize();
-        self.qinv.zeroize();
-        for val in self.crt_values.iter_mut() {
-            val.zeroize();
-        }
-        self.crt_values.clear();
-    }
-}
-
-impl Drop for PrecomputedValues {
-    fn drop(&mut self) {
-        self.zeroize();
-    }
-}
-
-/// Contains the precomputed Chinese remainder theorem values.
-#[derive(Debug, Clone)]
-pub(crate) struct CRTValue {
-    /// D mod (prime - 1)
-    pub(crate) exp: BigInt,
-    /// R·Coeff ≡ 1 mod Prime.
-    pub(crate) coeff: BigInt,
-    /// product of primes prior to this (inc p and q)
-    pub(crate) r: BigInt,
-}
-
-impl Zeroize for CRTValue {
-    fn zeroize(&mut self) {
-        self.exp.zeroize();
-        self.coeff.zeroize();
-        self.r.zeroize();
     }
 }
 
@@ -774,11 +573,13 @@ mod tests {
                 n: BigUint::from_u64(100).unwrap(),
                 e: BigUint::from_u64(200).unwrap(),
             },
-            privkey_components: RsaPrivateKeyComponents {
-                d: BigUint::from_u64(123).unwrap(),
-                primes: vec![],
-                precomputed: None,
-            },
+            privkey_components: RsaPrivateKeyComponents::new(
+                BigUint::from_u64(123).unwrap(),
+                vec![
+                    BigUint::from_u64(456).unwrap(),
+                    BigUint::from_u64(789).unwrap(),
+                ],
+            ),
         };
         let public_key: RsaPublicKey = private_key.into();
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -63,6 +63,12 @@ pub struct RsaPrivateKey {
     privkey_components: RsaPrivateKeyComponents,
 }
 
+impl AsRef<RsaPublicKey> for RsaPrivateKey {
+    fn as_ref(&self) -> &RsaPublicKey {
+        &self.pubkey_components
+    }
+}
+
 /*
  * Splitting privkey components to a separate struct breaks Serialization backwards compatibility.
  * cfg(flatten) can not help in this case, as it also changes the representation of the struct to
@@ -349,6 +355,16 @@ impl RsaPrivateKey {
         })
     }
 
+    pub(crate) fn new_internal(
+        pubkey_components: RsaPublicKey,
+        privkey_components: RsaPrivateKeyComponents,
+    ) -> RsaPrivateKey {
+        RsaPrivateKey {
+            pubkey_components,
+            privkey_components,
+        }
+    }
+
     /// Get the public key from the private key, cloning `n` and `e`.
     ///
     /// Generally this is not needed since `RsaPrivateKey` implements the `PublicKey` trait,
@@ -517,6 +533,10 @@ impl RsaPrivateKey {
             } => pss::sign::<R, _>(rng, true, self, digest_in, salt_len, &mut *digest),
             _ => Err(Error::InvalidPaddingScheme),
         }
+    }
+
+    pub(crate) fn privkey(self) -> RsaPrivateKeyComponents {
+        self.privkey_components
     }
 }
 

--- a/src/keyparts.rs
+++ b/src/keyparts.rs
@@ -1,0 +1,213 @@
+use alloc::vec::Vec;
+use num_bigint::traits::ModInverse;
+use num_bigint::Sign::Plus;
+use num_bigint::{BigInt, BigUint};
+use num_traits::One;
+#[cfg(feature = "serde")]
+use serde_crate::{Deserialize, Serialize};
+use zeroize::Zeroize;
+
+use crate::errors::{Error, Result};
+
+pub trait PublicKeyParts {
+    /// Returns the modulus of the key.
+    fn n(&self) -> &BigUint;
+
+    /// Returns the public exponent of the key.
+    fn e(&self) -> &BigUint;
+
+    /// Returns the modulus size in bytes. Raw signatures and ciphertexts for
+    /// or by this public key will have the same size.
+    fn size(&self) -> usize {
+        (self.n().bits() + 7) / 8
+    }
+}
+
+pub trait PrivateKeyParts {
+    /// Returns the private exponent of the key.
+    fn d(&self) -> &BigUint;
+    /// Returns the prime factors.
+    fn primes(&self) -> &[BigUint];
+}
+
+/// Internal trait, not to be exported outside of the crate
+pub trait PrivateKeyPartsInt: PrivateKeyParts {
+    fn precomputed(&self) -> &Option<PrecomputedValues>;
+}
+
+/// Internal representation of the public part of an RSA key.
+#[derive(Debug, Clone)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
+pub(crate) struct RsaPrivateKeyComponents {
+    /// Private exponent
+    d: BigUint,
+    /// Prime factors of N, contains >= 2 elements.
+    primes: Vec<BigUint>,
+    /// precomputed values to speed up private operations
+    #[cfg_attr(feature = "serde", serde(skip))]
+    precomputed: Option<PrecomputedValues>,
+}
+
+impl RsaPrivateKeyComponents {
+    pub fn new(d: BigUint, primes: Vec<BigUint>) -> RsaPrivateKeyComponents {
+        let mut k = RsaPrivateKeyComponents {
+            d,
+            primes,
+            precomputed: None,
+        };
+
+        let _ = k.precompute();
+
+        k
+    }
+    /// Performs some calculations to speed up private key operations.
+    pub fn precompute(&mut self) -> Result<()> {
+        if self.precomputed.is_some() {
+            return Ok(());
+        }
+
+        let dp = &self.d % (&self.primes[0] - BigUint::one());
+        let dq = &self.d % (&self.primes[1] - BigUint::one());
+        let qinv = self.primes[1]
+            .clone()
+            .mod_inverse(&self.primes[0])
+            .ok_or(Error::InvalidPrime)?;
+
+        let mut r: BigUint = &self.primes[0] * &self.primes[1];
+        let crt_values: Vec<CRTValue> = {
+            let mut values = Vec::with_capacity(self.primes.len() - 2);
+            for prime in &self.primes[2..] {
+                let res = CRTValue {
+                    exp: BigInt::from_biguint(Plus, &self.d % (prime - BigUint::one())),
+                    r: BigInt::from_biguint(Plus, r.clone()),
+                    coeff: BigInt::from_biguint(
+                        Plus,
+                        r.clone()
+                            .mod_inverse(prime)
+                            .ok_or(Error::InvalidCoefficient)?
+                            .to_biguint()
+                            .unwrap(),
+                    ),
+                };
+                r *= prime;
+
+                values.push(res);
+            }
+            values
+        };
+
+        self.precomputed = Some(PrecomputedValues {
+            dp,
+            dq,
+            qinv,
+            crt_values,
+        });
+
+        Ok(())
+    }
+
+    /// Clears precomputed values by setting to None
+    pub fn clear_precomputed(&mut self) {
+        self.precomputed = None;
+    }
+}
+
+impl PartialEq for RsaPrivateKeyComponents {
+    #[inline]
+    fn eq(&self, other: &RsaPrivateKeyComponents) -> bool {
+        self.d == other.d && self.primes == other.primes
+    }
+}
+
+impl Zeroize for RsaPrivateKeyComponents {
+    fn zeroize(&mut self) {
+        self.d.zeroize();
+        for prime in self.primes.iter_mut() {
+            prime.zeroize();
+        }
+        self.primes.clear();
+        if self.precomputed.is_some() {
+            self.precomputed.take().unwrap().zeroize();
+        }
+    }
+}
+
+impl Drop for RsaPrivateKeyComponents {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl PrivateKeyParts for RsaPrivateKeyComponents {
+    /// Returns the private exponent of the key.
+    fn d(&self) -> &BigUint {
+        &self.d
+    }
+    /// Returns the prime factors.
+    fn primes(&self) -> &[BigUint] {
+        &self.primes
+    }
+}
+
+impl PrivateKeyPartsInt for RsaPrivateKeyComponents {
+    fn precomputed(&self) -> &Option<PrecomputedValues> {
+        &self.precomputed
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PrecomputedValues {
+    /// D mod (P-1)
+    pub(crate) dp: BigUint,
+    /// D mod (Q-1)
+    pub(crate) dq: BigUint,
+    /// Q^-1 mod P
+    pub(crate) qinv: BigInt,
+
+    /// CRTValues is used for the 3rd and subsequent primes. Due to a
+    /// historical accident, the CRT for the first two primes is handled
+    /// differently in PKCS#1 and interoperability is sufficiently
+    /// important that we mirror this.
+    pub(crate) crt_values: Vec<CRTValue>,
+}
+
+impl Zeroize for PrecomputedValues {
+    fn zeroize(&mut self) {
+        self.dp.zeroize();
+        self.dq.zeroize();
+        self.qinv.zeroize();
+        for val in self.crt_values.iter_mut() {
+            val.zeroize();
+        }
+        self.crt_values.clear();
+    }
+}
+
+impl Drop for PrecomputedValues {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+/// Contains the precomputed Chinese remainder theorem values.
+#[derive(Debug, Clone)]
+pub(crate) struct CRTValue {
+    /// D mod (prime - 1)
+    pub(crate) exp: BigInt,
+    /// R·Coeff ≡ 1 mod Prime.
+    pub(crate) coeff: BigInt,
+    /// product of primes prior to this (inc p and q)
+    pub(crate) r: BigInt,
+}
+
+impl Zeroize for CRTValue {
+    fn zeroize(&mut self) {
+        self.exp.zeroize();
+        self.coeff.zeroize();
+        self.r.zeroize();
+    }
+}

--- a/src/keyparts.rs
+++ b/src/keyparts.rs
@@ -28,6 +28,12 @@ pub trait PrivateKeyParts {
     fn d(&self) -> &BigUint;
     /// Returns the prime factors.
     fn primes(&self) -> &[BigUint];
+    /// Compute CRT coefficient: `(1/q) mod p`.
+    fn crt_coefficient(&self) -> Option<BigUint> {
+        (&self.primes()[1])
+            .mod_inverse(&self.primes()[0])?
+            .to_biguint()
+    }
 }
 
 /// Internal trait, not to be exported outside of the crate

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,7 +216,7 @@ mod raw;
 pub use pkcs1;
 pub use pkcs8;
 
-pub use self::key::{PublicKey, PublicKeyParts, RsaPrivateKey, RsaPublicKey};
+pub use self::key::{PrivateKeyParts, PublicKey, PublicKeyParts, RsaPrivateKey, RsaPublicKey};
 pub use self::padding::PaddingScheme;
 
 /// Internal raw RSA functions.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,13 +210,15 @@ pub mod pss;
 mod dummy_rng;
 mod encoding;
 mod key;
+mod keyparts;
 mod oaep;
 mod raw;
 
 pub use pkcs1;
 pub use pkcs8;
 
-pub use self::key::{PrivateKeyParts, PublicKey, PublicKeyParts, RsaPrivateKey, RsaPublicKey};
+pub use self::key::{PublicKey, RsaPrivateKey, RsaPublicKey};
+pub use self::keyparts::{PrivateKeyParts, PublicKeyParts};
 pub use self::padding::PaddingScheme;
 
 /// Internal raw RSA functions.

--- a/src/pkcs1v15.rs
+++ b/src/pkcs1v15.rs
@@ -9,7 +9,7 @@ use rand_core::{CryptoRng, RngCore};
 #[cfg(feature = "hazmat")]
 use signature::hazmat::{PrehashSigner, PrehashVerifier};
 use signature::{
-    DigestSigner, DigestVerifier, RandomizedDigestSigner, RandomizedSigner,
+    DigestSigner, DigestVerifier, Keypair, RandomizedDigestSigner, RandomizedSigner,
     Signature as SignSignature, Signer, Verifier,
 };
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
@@ -426,6 +426,13 @@ where
     fn as_ref(&self) -> &VerifyingKey<D> {
         &self.verifying_key
     }
+}
+
+impl<D> Keypair<Signature> for SigningKey<D>
+where
+    D: Digest,
+{
+    type VerifyingKey = VerifyingKey<D>;
 }
 
 impl<D> Signer<Signature> for SigningKey<D>

--- a/src/pss.rs
+++ b/src/pss.rs
@@ -10,7 +10,8 @@ use rand_core::{CryptoRng, RngCore};
 #[cfg(feature = "hazmat")]
 use signature::hazmat::{PrehashVerifier, RandomizedPrehashSigner};
 use signature::{
-    DigestVerifier, RandomizedDigestSigner, RandomizedSigner, Signature as SignSignature, Verifier,
+    DigestVerifier, Keypair, RandomizedDigestSigner, RandomizedSigner, Signature as SignSignature,
+    Verifier,
 };
 use subtle::ConstantTimeEq;
 
@@ -626,6 +627,13 @@ where
     }
 }
 
+impl<D> Keypair<Signature> for SigningKey<D>
+where
+    D: Digest,
+{
+    type VerifyingKey = VerifyingKey<D>;
+}
+
 impl<D> AsRef<VerifyingKey<D>> for SigningKey<D>
 where
     D: Digest,
@@ -797,6 +805,13 @@ where
     fn as_ref(&self) -> &VerifyingKey<D> {
         &self.verifying_key
     }
+}
+
+impl<D> Keypair<Signature> for BlindedSigningKey<D>
+where
+    D: Digest,
+{
+    type VerifyingKey = VerifyingKey<D>;
 }
 
 impl<D> RandomizedSigner<Signature> for BlindedSigningKey<D>

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -5,7 +5,7 @@ use zeroize::Zeroize;
 
 use crate::errors::{Error, Result};
 use crate::internals;
-use crate::key::{PrivateKeyPartsInt, PublicKeyParts};
+use crate::keyparts::{PrivateKeyPartsInt, PublicKeyParts};
 
 pub trait EncryptionPrimitive {
     /// Do NOT use directly! Only for implementors.

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -5,7 +5,7 @@ use zeroize::Zeroize;
 
 use crate::errors::{Error, Result};
 use crate::internals;
-use crate::key::{RsaPrivateKey, RsaPublicKey};
+use crate::key::{PrivateKeyPartsInt, PublicKeyParts};
 
 pub trait EncryptionPrimitive {
     /// Do NOT use directly! Only for implementors.
@@ -22,7 +22,10 @@ pub trait DecryptionPrimitive {
     ) -> Result<Vec<u8>>;
 }
 
-impl EncryptionPrimitive for RsaPublicKey {
+impl<PK> EncryptionPrimitive for PK
+where
+    PK: PublicKeyParts,
+{
     fn raw_encryption_primitive(&self, plaintext: &[u8], pad_size: usize) -> Result<Vec<u8>> {
         let mut m = BigUint::from_bytes_be(plaintext);
         let mut c = internals::encrypt(self, &m);
@@ -42,7 +45,10 @@ impl EncryptionPrimitive for RsaPublicKey {
     }
 }
 
-impl DecryptionPrimitive for RsaPrivateKey {
+impl<SK> DecryptionPrimitive for SK
+where
+    SK: PrivateKeyPartsInt + PublicKeyParts,
+{
     fn raw_decryption_primitive<R: RngCore + CryptoRng>(
         &self,
         rng: Option<&mut R>,

--- a/tests/pkcs1.rs
+++ b/tests/pkcs1.rs
@@ -3,7 +3,7 @@
 use hex_literal::hex;
 use rsa::{
     pkcs1::{DecodeRsaPrivateKey, DecodeRsaPublicKey, EncodeRsaPrivateKey, EncodeRsaPublicKey},
-    PublicKeyParts, RsaPrivateKey, RsaPublicKey,
+    PrivateKeyParts, PublicKeyParts, RsaPrivateKey, RsaPublicKey,
 };
 
 #[cfg(feature = "pem")]

--- a/tests/pkcs8.rs
+++ b/tests/pkcs8.rs
@@ -17,7 +17,7 @@ const RSA_2048_PUB_PEM: &str = include_str!("examples/pkcs8/rsa2048-pub.pem");
 use hex_literal::hex;
 use rsa::{
     pkcs8::{DecodePrivateKey, DecodePublicKey, EncodePrivateKey, EncodePublicKey},
-    PublicKeyParts, RsaPrivateKey, RsaPublicKey,
+    PrivateKeyParts, PublicKeyParts, RsaPrivateKey, RsaPublicKey,
 };
 
 #[cfg(feature = "pem")]


### PR DESCRIPTION
This is rather intrusive implementation. It reworks the way `RsaPrivateKey` is organized. Unfortunately it also meant that default `Serialize` an `Deserilialize` derivations provide a list of tokens that are not backwards-compatible. Thus I had to implement those traits manually.