### PR TITLE
Derive Clone and Debug for vk and sk

### DIFF
--- a/src/pkcs1v15.rs
+++ b/src/pkcs1v15.rs
@@ -303,6 +303,7 @@ fn non_zero_random_bytes<R: RngCore + CryptoRng>(rng: &mut R, data: &mut [u8]) {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct SigningKey<D>
 where
     D: Digest,
@@ -403,6 +404,7 @@ where
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct VerifyingKey<D>
 where
     D: Digest,

--- a/src/pss.rs
+++ b/src/pss.rs
@@ -518,6 +518,7 @@ where
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct SigningKey<D>
 where
     D: Digest,
@@ -658,6 +659,7 @@ where
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct VerifyingKey<D>
 where
     D: Digest,


### PR DESCRIPTION
- added Clone and Debug for SigningKey & VerifyingKey of pss and pkcs1v15

This is useful, and keep the counterpart in [ecdsa](https://github.com/RustCrypto/signatures/tree/master/ecdsa)