### PR TITLE
feat: iplement hazmat signature traits for PSS keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ subtle = { version = "2.1.1", default-features = false }
 digest = { version = "0.10.5", default-features = false, features = ["alloc", "oid"] }
 pkcs1 = { version = "0.4", default-features = false, features = ["pkcs8", "alloc"] }
 pkcs8 = { version = "0.9", default-features = false, features = ["alloc"] }
-signature = { version = "1.6.2", default-features = false , features = ["digest-preview", "rand-preview"] }
+signature = { version = "1.6.4", default-features = false , features = ["digest-preview", "rand-preview"] }
 zeroize = { version = "1", features = ["alloc"] }
 
 # Temporary workaround until https://github.com/dignifiedquire/num-bigint/pull/42 lands


### PR DESCRIPTION
Implement PrehashSigner and PrehashVerifier traits for PSS key structures.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>