### PR TITLE
Fix `signature` version requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,7 @@ subtle = { version = "2.1.1", default-features = false }
 digest = { version = "0.10.5", default-features = false, features = ["alloc", "oid"] }
 pkcs1 = { version = "0.4", default-features = false, features = ["pkcs8", "alloc"] }
 pkcs8 = { version = "0.9", default-features = false, features = ["alloc"] }
-# To keep the `digest` and `rand_core` versions properly pinned, specify exact version
-signature = { version = ">=1.5, <1.7", default-features = false , features = ["digest-preview", "rand-preview"] }
+signature = { version = "1.6.2", default-features = false , features = ["digest-preview", "rand-preview"] }
 zeroize = { version = "1", features = ["alloc"] }
 
 # Temporary workaround until https://github.com/dignifiedquire/num-bigint/pull/42 lands


### PR DESCRIPTION
The crate is now using the `PrehashSigner`/`PrehashVerifier` traits, which were added in `signature` v1.6.1.

However, that release was also yanked, so this commit pins to 1.6.2.