### PR TITLE
feat: switch to version 2.0 (pre) of the  signature crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,13 @@ num-bigint = { version = "0.8.1", features = ["i128", "u64_digit", "prime", "zer
 num-traits = { version= "0.2.9", default-features = false, features = ["libm"] }
 num-integer = { version = "0.1.39", default-features = false }
 num-iter = { version = "0.1.37", default-features = false }
-rand_core = { version = "0.6", default-features = false }
+rand_core = { version = "0.6.4", default-features = false }
 byteorder = { version = "1.3.1", default-features = false }
 subtle = { version = "2.1.1", default-features = false }
 digest = { version = "0.10.5", default-features = false, features = ["alloc", "oid"] }
 pkcs1 = { version = "0.4", default-features = false, features = ["pkcs8", "alloc"] }
 pkcs8 = { version = "0.9", default-features = false, features = ["alloc"] }
-signature = { version = "1.6.4", default-features = false , features = ["digest-preview", "rand-preview"] }
+signature = { version = "2.0.0-pre.2", default-features = false , features = ["digest-preview", "rand-preview"] }
 zeroize = { version = "1", features = ["alloc"] }
 
 # Temporary workaround until https://github.com/dignifiedquire/num-bigint/pull/42 lands
@@ -53,7 +53,7 @@ name = "key"
 
 [features]
 default = ["std", "pem"]
-hazmat = ["signature/hazmat-preview"]
+hazmat = []
 nightly = ["num-bigint/nightly"]
 serde = ["num-bigint/serde", "serde_crate"]
 expose-internals = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsa"
-version = "0.7.2"
+version = "0.8.0-pre"
 authors = ["RustCrypto Developers", "dignifiedquire <dignifiedquire@gmail.com>"]
 edition = "2021"
 description = "Pure Rust RSA implementation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ name = "key"
 
 [features]
 default = ["std", "pem"]
-hazmat = []
 nightly = ["num-bigint/nightly"]
 serde = ["num-bigint/serde", "serde_crate"]
 expose-internals = []

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -6,7 +6,7 @@ use num_bigint::{BigUint, RandPrime};
 #[allow(unused_imports)]
 use num_traits::Float;
 use num_traits::{FromPrimitive, One, Zero};
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRngCore;
 
 use crate::errors::{Error, Result};
 use crate::key::RsaPrivateKey;
@@ -29,7 +29,7 @@ const EXP: u64 = 65537;
 ///
 /// [1]: https://patents.google.com/patent/US4405829A/en
 /// [2]: https://cacr.uwaterloo.ca/techreports/2006/cacr2006-16.pdf
-pub fn generate_multi_prime_key<R: RngCore + CryptoRng>(
+pub fn generate_multi_prime_key<R: CryptoRngCore + ?Sized>(
     rng: &mut R,
     nprimes: usize,
     bit_size: usize,
@@ -49,7 +49,7 @@ pub fn generate_multi_prime_key<R: RngCore + CryptoRng>(
 ///
 /// [1]: https://patents.google.com/patent/US4405829A/en
 /// [2]: http://www.cacr.math.uwaterloo.ca/techreports/2006/cacr2006-16.pdf
-pub fn generate_multi_prime_key_with_exp<R: RngCore + CryptoRng>(
+pub fn generate_multi_prime_key_with_exp<R: CryptoRngCore + ?Sized>(
     rng: &mut R,
     nprimes: usize,
     bit_size: usize,

--- a/src/key.rs
+++ b/src/key.rs
@@ -4,7 +4,7 @@ use num_bigint::traits::ModInverse;
 use num_bigint::Sign::Plus;
 use num_bigint::{BigInt, BigUint};
 use num_traits::{One, ToPrimitive};
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRngCore;
 #[cfg(feature = "serde")]
 use serde_crate::{Deserialize, Serialize};
 use zeroize::Zeroize;
@@ -173,7 +173,7 @@ impl From<&RsaPrivateKey> for RsaPublicKey {
 /// Generic trait for operations on a public key.
 pub trait PublicKey: EncryptionPrimitive + PublicKeyParts {
     /// Encrypt the given message.
-    fn encrypt<R: RngCore + CryptoRng>(
+    fn encrypt<R: CryptoRngCore>(
         &self,
         rng: &mut R,
         padding: PaddingScheme,
@@ -198,7 +198,7 @@ impl PublicKeyParts for RsaPublicKey {
 }
 
 impl PublicKey for RsaPublicKey {
-    fn encrypt<R: RngCore + CryptoRng>(
+    fn encrypt<R: CryptoRngCore>(
         &self,
         rng: &mut R,
         padding: PaddingScheme,
@@ -281,7 +281,7 @@ impl PrivateKey for RsaPrivateKey {}
 
 impl RsaPrivateKey {
     /// Generate a new Rsa key pair of the given bit size using the passed in `rng`.
-    pub fn new<R: RngCore + CryptoRng>(rng: &mut R, bit_size: usize) -> Result<RsaPrivateKey> {
+    pub fn new<R: CryptoRngCore + ?Sized>(rng: &mut R, bit_size: usize) -> Result<RsaPrivateKey> {
         generate_multi_prime_key(rng, 2, bit_size)
     }
 
@@ -289,7 +289,7 @@ impl RsaPrivateKey {
     /// using the passed in `rng`.
     ///
     /// Unless you have specific needs, you should use `RsaPrivateKey::new` instead.
-    pub fn new_with_exp<R: RngCore + CryptoRng>(
+    pub fn new_with_exp<R: CryptoRngCore + ?Sized>(
         rng: &mut R,
         bit_size: usize,
         exp: &BigUint,
@@ -473,7 +473,7 @@ impl RsaPrivateKey {
     /// Decrypt the given message.
     ///
     /// Uses `rng` to blind the decryption process.
-    pub fn decrypt_blinded<R: RngCore + CryptoRng>(
+    pub fn decrypt_blinded<R: CryptoRngCore>(
         &self,
         rng: &mut R,
         padding: PaddingScheme,
@@ -516,7 +516,7 @@ impl RsaPrivateKey {
     /// Sign the given digest using the provided rng
     ///
     /// Use `rng` for signature process.
-    pub fn sign_with_rng<R: RngCore + CryptoRng>(
+    pub fn sign_with_rng<R: CryptoRngCore>(
         &self,
         rng: &mut R,
         padding: PaddingScheme,
@@ -534,7 +534,7 @@ impl RsaPrivateKey {
     /// Sign the given digest.
     ///
     /// Use `rng` for blinding.
-    pub fn sign_blinded<R: RngCore + CryptoRng>(
+    pub fn sign_blinded<R: CryptoRngCore>(
         &self,
         rng: &mut R,
         padding: PaddingScheme,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@
 //! ```
 //! use rsa::RsaPrivateKey;
 //! use rsa::pkcs1v15::{SigningKey, VerifyingKey};
-//! use rsa::signature::{RandomizedSigner, Signature, Verifier};
+//! use rsa::signature::{RandomizedSigner, SignatureEncoding, Verifier};
 //! use sha2::{Digest, Sha256};
 //!
 //! let mut rng = rand::thread_rng();
@@ -72,7 +72,7 @@
 //! // Sign
 //! let data = b"hello world";
 //! let signature = signing_key.sign_with_rng(&mut rng, data);
-//! assert_ne!(signature.as_bytes(), data);
+//! assert_ne!(signature.to_bytes().as_ref(), data.as_slice());
 //!
 //! // Verify
 //! verifying_key.verify(data, &signature).expect("failed to verify");
@@ -82,7 +82,7 @@
 //! ```
 //! use rsa::RsaPrivateKey;
 //! use rsa::pss::{BlindedSigningKey, VerifyingKey};
-//! use rsa::signature::{RandomizedSigner, Signature, Verifier};
+//! use rsa::signature::{RandomizedSigner, SignatureEncoding, Verifier};
 //! use sha2::{Digest, Sha256};
 //!
 //! let mut rng = rand::thread_rng();
@@ -95,7 +95,7 @@
 //! // Sign
 //! let data = b"hello world";
 //! let signature = signing_key.sign_with_rng(&mut rng, data);
-//! assert_ne!(signature.as_bytes(), data);
+//! assert_ne!(signature.to_bytes().as_ref(), data);
 //!
 //! // Verify
 //! verifying_key.verify(data, &signature).expect("failed to verify");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@
 //! ```
 //! use rsa::RsaPrivateKey;
 //! use rsa::pkcs1v15::{SigningKey, VerifyingKey};
-//! use rsa::signature::{RandomizedSigner, SignatureEncoding, Verifier};
+//! use rsa::signature::{Keypair, RandomizedSigner, SignatureEncoding, Verifier};
 //! use sha2::{Digest, Sha256};
 //!
 //! let mut rng = rand::thread_rng();
@@ -67,7 +67,7 @@
 //! let bits = 2048;
 //! let private_key = RsaPrivateKey::new(&mut rng, bits).expect("failed to generate a key");
 //! let signing_key = SigningKey::<Sha256>::new_with_prefix(private_key);
-//! let verifying_key: VerifyingKey<_> = (&signing_key).into();
+//! let verifying_key = signing_key.verifying_key();
 //!
 //! // Sign
 //! let data = b"hello world";
@@ -82,7 +82,7 @@
 //! ```
 //! use rsa::RsaPrivateKey;
 //! use rsa::pss::{BlindedSigningKey, VerifyingKey};
-//! use rsa::signature::{RandomizedSigner, SignatureEncoding, Verifier};
+//! use rsa::signature::{Keypair,RandomizedSigner, SignatureEncoding, Verifier};
 //! use sha2::{Digest, Sha256};
 //!
 //! let mut rng = rand::thread_rng();
@@ -90,7 +90,7 @@
 //! let bits = 2048;
 //! let private_key = RsaPrivateKey::new(&mut rng, bits).expect("failed to generate a key");
 //! let signing_key = BlindedSigningKey::<Sha256>::new(private_key);
-//! let verifying_key: VerifyingKey<_> = (&signing_key).into();
+//! let verifying_key = signing_key.verifying_key();
 //!
 //! // Sign
 //! let data = b"hello world";

--- a/src/pkcs1v15.rs
+++ b/src/pkcs1v15.rs
@@ -6,18 +6,18 @@
 //!
 //! [RFC8017 § 8.2]: https://datatracker.ietf.org/doc/html/rfc8017#section-8.2
 
+use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::fmt::{Debug, Display, Formatter, LowerHex, UpperHex};
 use core::marker::PhantomData;
-use core::ops::Deref;
 use digest::Digest;
 use pkcs8::{AssociatedOid, Document, EncodePrivateKey, EncodePublicKey, SecretDocument};
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRngCore;
 #[cfg(feature = "hazmat")]
 use signature::hazmat::{PrehashSigner, PrehashVerifier};
 use signature::{
-    DigestSigner, DigestVerifier, RandomizedDigestSigner, RandomizedSigner,
-    Signature as SignSignature, Signer, Verifier,
+    DigestSigner, DigestVerifier, RandomizedDigestSigner, RandomizedSigner, SignatureEncoding,
+    Signer, Verifier,
 };
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 use zeroize::Zeroizing;
@@ -30,60 +30,52 @@ use crate::{RsaPrivateKey, RsaPublicKey};
 /// PKCS#1 v1.5 signatures as described in [RFC8017 § 8.2].
 ///
 /// [RFC8017 § 8.2]: https://datatracker.ietf.org/doc/html/rfc8017#section-8.2
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Signature {
-    bytes: Vec<u8>,
+    bytes: Box<[u8]>,
 }
 
-impl signature::Signature for Signature {
-    fn from_bytes(bytes: &[u8]) -> signature::Result<Self> {
-        Ok(Signature {
-            bytes: bytes.into(),
-        })
-    }
-
-    fn as_bytes(&self) -> &[u8] {
-        self.bytes.as_slice()
-    }
+impl SignatureEncoding for Signature {
+    type Repr = Box<[u8]>;
 }
 
-impl From<Vec<u8>> for Signature {
-    fn from(bytes: Vec<u8>) -> Self {
+impl From<Box<[u8]>> for Signature {
+    fn from(bytes: Box<[u8]>) -> Self {
         Self { bytes }
     }
 }
 
-impl Deref for Signature {
-    type Target = [u8];
+impl<'a> TryFrom<&'a [u8]> for Signature {
+    type Error = signature::Error;
 
-    fn deref(&self) -> &Self::Target {
-        self.as_bytes()
+    fn try_from(bytes: &'a [u8]) -> signature::Result<Self> {
+        Ok(Self {
+            bytes: bytes.into(),
+        })
     }
 }
 
-impl PartialEq for Signature {
-    fn eq(&self, other: &Self) -> bool {
-        self.as_bytes() == other.as_bytes()
-    }
-}
-
-impl Eq for Signature {}
-
-impl Debug for Signature {
-    fn fmt(&self, fmt: &mut Formatter<'_>) -> core::result::Result<(), core::fmt::Error> {
-        fmt.debug_list().entries(self.as_bytes().iter()).finish()
+impl From<Signature> for Box<[u8]> {
+    fn from(signature: Signature) -> Box<[u8]> {
+        signature.bytes
     }
 }
 
 impl AsRef<[u8]> for Signature {
     fn as_ref(&self) -> &[u8] {
-        self.as_bytes()
+        self.bytes.as_ref()
+    }
+}
+
+impl Debug for Signature {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> core::result::Result<(), core::fmt::Error> {
+        fmt.debug_list().entries(self.bytes.iter()).finish()
     }
 }
 
 impl LowerHex for Signature {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        for byte in self.as_bytes() {
+        for byte in self.bytes.iter() {
             write!(f, "{:02x}", byte)?;
         }
         Ok(())
@@ -92,7 +84,7 @@ impl LowerHex for Signature {
 
 impl UpperHex for Signature {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        for byte in self.as_bytes() {
+        for byte in self.bytes.iter() {
             write!(f, "{:02X}", byte)?;
         }
         Ok(())
@@ -109,7 +101,7 @@ impl Display for Signature {
 /// scheme from PKCS#1 v1.5.  The message must be no longer than the
 /// length of the public modulus minus 11 bytes.
 #[inline]
-pub(crate) fn encrypt<R: RngCore + CryptoRng, PK: PublicKey>(
+pub(crate) fn encrypt<R: CryptoRngCore, PK: PublicKey>(
     rng: &mut R,
     pub_key: &PK,
     msg: &[u8],
@@ -141,7 +133,7 @@ pub(crate) fn encrypt<R: RngCore + CryptoRng, PK: PublicKey>(
 /// forge signatures as if they had the private key. See
 /// `decrypt_session_key` for a way of solving this problem.
 #[inline]
-pub(crate) fn decrypt<R: RngCore + CryptoRng, SK: PrivateKey>(
+pub(crate) fn decrypt<R: CryptoRngCore, SK: PrivateKey>(
     rng: Option<&mut R>,
     priv_key: &SK,
     ciphertext: &[u8],
@@ -170,7 +162,7 @@ pub(crate) fn decrypt<R: RngCore + CryptoRng, SK: PrivateKey>(
 /// messages to signatures and identify the signed messages. As ever,
 /// signatures provide authenticity, not confidentiality.
 #[inline]
-pub(crate) fn sign<R: RngCore + CryptoRng, SK: PrivateKey>(
+pub(crate) fn sign<R: CryptoRngCore, SK: PrivateKey>(
     rng: Option<&mut R>,
     priv_key: &SK,
     prefix: &[u8],
@@ -258,7 +250,7 @@ where
 /// in order to maintain constant memory access patterns. If the plaintext was
 /// valid then index contains the index of the original message in em.
 #[inline]
-fn decrypt_inner<R: RngCore + CryptoRng, SK: PrivateKey>(
+fn decrypt_inner<R: CryptoRngCore, SK: PrivateKey>(
     rng: Option<&mut R>,
     priv_key: &SK,
     ciphertext: &[u8],
@@ -303,7 +295,7 @@ fn decrypt_inner<R: RngCore + CryptoRng, SK: PrivateKey>(
 /// Fills the provided slice with random values, which are guaranteed
 /// to not be zero.
 #[inline]
-fn non_zero_random_bytes<R: RngCore + CryptoRng>(rng: &mut R, data: &mut [u8]) {
+fn non_zero_random_bytes<R: CryptoRngCore>(rng: &mut R, data: &mut [u8]) {
     rng.fill_bytes(data);
 
     for el in data {
@@ -407,7 +399,7 @@ where
 {
     fn try_sign(&self, msg: &[u8]) -> signature::Result<Signature> {
         sign::<DummyRng, _>(None, &self.inner, &self.prefix, &D::digest(msg))
-            .map(|v| v.into())
+            .map(|v| v.into_boxed_slice().into())
             .map_err(|e| e.into())
     }
 }
@@ -418,11 +410,11 @@ where
 {
     fn try_sign_with_rng(
         &self,
-        mut rng: impl CryptoRng + RngCore,
+        rng: &mut impl CryptoRngCore,
         msg: &[u8],
     ) -> signature::Result<Signature> {
-        sign(Some(&mut rng), &self.inner, &self.prefix, &D::digest(msg))
-            .map(|v| v.into())
+        sign(Some(rng), &self.inner, &self.prefix, &D::digest(msg))
+            .map(|v| v.into_boxed_slice().into())
             .map_err(|e| e.into())
     }
 }
@@ -433,7 +425,7 @@ where
 {
     fn try_sign_digest(&self, digest: D) -> signature::Result<Signature> {
         sign::<DummyRng, _>(None, &self.inner, &self.prefix, &digest.finalize())
-            .map(|v| v.into())
+            .map(|v| v.into_boxed_slice().into())
             .map_err(|e| e.into())
     }
 }
@@ -444,17 +436,12 @@ where
 {
     fn try_sign_digest_with_rng(
         &self,
-        mut rng: impl CryptoRng + RngCore,
+        rng: &mut impl CryptoRngCore,
         digest: D,
     ) -> signature::Result<Signature> {
-        sign(
-            Some(&mut rng),
-            &self.inner,
-            &self.prefix,
-            &digest.finalize(),
-        )
-        .map(|v| v.into())
-        .map_err(|e| e.into())
+        sign(Some(rng), &self.inner, &self.prefix, &digest.finalize())
+            .map(|v| v.into_boxed_slice().into())
+            .map_err(|e| e.into())
     }
 }
 
@@ -465,7 +452,7 @@ where
 {
     fn sign_prehash(&self, prehash: &[u8]) -> signature::Result<Signature> {
         sign::<DummyRng, _>(None, &self.inner, &self.prefix, prehash)
-            .map(|v| v.into())
+            .map(|v| v.into_boxed_slice().into())
             .map_err(|e| e.into())
     }
 }
@@ -621,11 +608,14 @@ mod tests {
     use num_bigint::BigUint;
     use num_traits::FromPrimitive;
     use num_traits::Num;
-    use rand_chacha::{rand_core::SeedableRng, ChaCha8Rng};
+    use rand_chacha::{
+        rand_core::{RngCore, SeedableRng},
+        ChaCha8Rng,
+    };
     use sha1::{Digest, Sha1};
     use sha2::Sha256;
     use sha3::Sha3_256;
-    use signature::{RandomizedSigner, Signature, Signer, Verifier};
+    use signature::{RandomizedSigner, Signer, Verifier};
 
     use crate::{PaddingScheme, PublicKey, PublicKeyParts, RsaPrivateKey, RsaPublicKey};
 
@@ -919,8 +909,10 @@ mod tests {
         let verifying_key = VerifyingKey::<Sha1>::new_with_prefix(pub_key);
 
         for (text, sig, expected) in &tests {
-            let result =
-                verifying_key.verify(text.as_bytes(), &Signature::from_bytes(sig).unwrap());
+            let result = verifying_key.verify(
+                text.as_bytes(),
+                &Signature::try_from(sig.as_slice()).unwrap(),
+            );
             match expected {
                 true => result.expect("failed to verify"),
                 false => {
@@ -958,7 +950,8 @@ mod tests {
         for (text, sig, expected) in &tests {
             let mut digest = Sha1::new();
             digest.update(text.as_bytes());
-            let result = verifying_key.verify_digest(digest, &Signature::from_bytes(sig).unwrap());
+            let result =
+                verifying_key.verify_digest(digest, &Signature::try_from(sig.as_slice()).unwrap());
             match expected {
                 true => result.expect("failed to verify"),
                 false => {
@@ -997,7 +990,10 @@ mod tests {
 
         let verifying_key: VerifyingKey<_> = (&signing_key).into();
         verifying_key
-            .verify_prehash(msg, &Signature::from_bytes(&expected_sig).unwrap())
+            .verify_prehash(
+                msg,
+                &Signature::try_from(expected_sig.into_boxed_slice()).unwrap(),
+            )
             .expect("failed to verify");
     }
 }

--- a/src/pkcs1v15.rs
+++ b/src/pkcs1v15.rs
@@ -13,9 +13,8 @@ use core::marker::PhantomData;
 use digest::Digest;
 use pkcs8::{AssociatedOid, Document, EncodePrivateKey, EncodePublicKey, SecretDocument};
 use rand_core::CryptoRngCore;
-#[cfg(feature = "hazmat")]
-use signature::hazmat::{PrehashSigner, PrehashVerifier};
 use signature::{
+    hazmat::{PrehashSigner, PrehashVerifier},
     DigestSigner, DigestVerifier, Keypair, RandomizedDigestSigner, RandomizedSigner,
     SignatureEncoding, Signer, Verifier,
 };
@@ -437,7 +436,6 @@ where
     }
 }
 
-#[cfg(feature = "hazmat")]
 impl<D> PrehashSigner<Signature> for SigningKey<D>
 where
     D: Digest,
@@ -575,7 +573,6 @@ where
     }
 }
 
-#[cfg(feature = "hazmat")]
 impl<D> PrehashVerifier<Signature> for VerifyingKey<D>
 where
     D: Digest,
@@ -971,7 +968,6 @@ mod tests {
             .expect("failed to verify");
     }
 
-    #[cfg(feature = "hazmat")]
     #[test]
     fn test_unpadded_signature_hazmat() {
         let msg = b"Thu Dec 19 18:06:16 EST 2013\n";

--- a/src/pkcs1v15.rs
+++ b/src/pkcs1v15.rs
@@ -332,6 +332,15 @@ where
             phantom: Default::default(),
         }
     }
+
+    /// Generate a new signing key.
+    pub fn random<R: CryptoRngCore + ?Sized>(rng: &mut R, bit_size: usize) -> Result<Self> {
+        Ok(Self {
+            inner: RsaPrivateKey::new(rng, bit_size)?,
+            prefix: Vec::new(),
+            phantom: Default::default(),
+        })
+    }
 }
 
 impl<D> From<RsaPrivateKey> for SigningKey<D>
@@ -356,13 +365,25 @@ impl<D> SigningKey<D>
 where
     D: Digest + AssociatedOid,
 {
-    /// Create a new verifying key with a prefix for the digest `D`.
+    /// Create a new signing key with a prefix for the digest `D`.
     pub fn new_with_prefix(key: RsaPrivateKey) -> Self {
         Self {
             inner: key,
             prefix: generate_prefix::<D>(),
             phantom: Default::default(),
         }
+    }
+
+    /// Generate a new signing key with a prefix for the digest `D`.
+    pub fn random_with_prefix<R: CryptoRngCore + ?Sized>(
+        rng: &mut R,
+        bit_size: usize,
+    ) -> Result<Self> {
+        Ok(Self {
+            inner: RsaPrivateKey::new(rng, bit_size)?,
+            prefix: generate_prefix::<D>(),
+            phantom: Default::default(),
+        })
     }
 }
 

--- a/src/pss.rs
+++ b/src/pss.rs
@@ -17,9 +17,8 @@ use core::marker::PhantomData;
 use digest::{Digest, DynDigest, FixedOutputReset};
 use pkcs8::{Document, EncodePrivateKey, EncodePublicKey, SecretDocument};
 use rand_core::CryptoRngCore;
-#[cfg(feature = "hazmat")]
-use signature::hazmat::{PrehashVerifier, RandomizedPrehashSigner};
 use signature::{
+    hazmat::{PrehashVerifier, RandomizedPrehashSigner},
     DigestVerifier, Keypair, RandomizedDigestSigner, RandomizedSigner, SignatureEncoding, Verifier,
 };
 use subtle::ConstantTimeEq;
@@ -631,7 +630,6 @@ where
     }
 }
 
-#[cfg(feature = "hazmat")]
 impl<D> RandomizedPrehashSigner<Signature> for SigningKey<D>
 where
     D: Digest + FixedOutputReset,
@@ -763,7 +761,6 @@ where
     }
 }
 
-#[cfg(feature = "hazmat")]
 impl<D> RandomizedPrehashSigner<Signature> for BlindedSigningKey<D>
 where
     D: Digest + FixedOutputReset,
@@ -865,7 +862,6 @@ where
     }
 }
 
-#[cfg(feature = "hazmat")]
 impl<D> PrehashVerifier<Signature> for VerifyingKey<D>
 where
     D: Digest + FixedOutputReset,
@@ -903,7 +899,6 @@ mod test {
     use num_traits::{FromPrimitive, Num};
     use rand_chacha::{rand_core::SeedableRng, ChaCha8Rng};
     use sha1::{Digest, Sha1};
-    #[cfg(feature = "hazmat")]
     use signature::hazmat::{PrehashVerifier, RandomizedPrehashSigner};
     use signature::{DigestVerifier, Keypair, RandomizedDigestSigner, RandomizedSigner, Verifier};
 
@@ -1160,7 +1155,6 @@ mod test {
         }
     }
 
-    #[cfg(feature = "hazmat")]
     #[test]
     fn test_verify_pss_hazmat() {
         let priv_key = get_private_key();
@@ -1198,7 +1192,6 @@ mod test {
         }
     }
 
-    #[cfg(feature = "hazmat")]
     #[test]
     fn test_sign_and_verify_pss_hazmat() {
         let priv_key = get_private_key();
@@ -1218,7 +1211,6 @@ mod test {
         }
     }
 
-    #[cfg(feature = "hazmat")]
     #[test]
     fn test_sign_and_verify_pss_blinded_hazmat() {
         let priv_key = get_private_key();

--- a/src/pss.rs
+++ b/src/pss.rs
@@ -558,6 +558,28 @@ where
             phantom: Default::default(),
         }
     }
+
+    /// Generate a new random RSASSA-PSS signing key.
+    pub fn random<R: CryptoRngCore + ?Sized>(rng: &mut R, bit_size: usize) -> Result<Self> {
+        Ok(Self {
+            inner: RsaPrivateKey::new(rng, bit_size)?,
+            salt_len: None,
+            phantom: Default::default(),
+        })
+    }
+
+    /// Generate a new random RSASSA-PSS signing key with a salt of the given length.
+    pub fn random_with_salt_len<R: CryptoRngCore + ?Sized>(
+        rng: &mut R,
+        bit_size: usize,
+        salt_len: usize,
+    ) -> Result<Self> {
+        Ok(Self {
+            inner: RsaPrivateKey::new(rng, bit_size)?,
+            salt_len: Some(salt_len),
+            phantom: Default::default(),
+        })
+    }
 }
 
 impl<D> From<RsaPrivateKey> for SigningKey<D>


### PR DESCRIPTION
Rework the crate to implement traits from the preview of the signature crate. Use Vec<u8> as Self::Repr type.

Note: I'm yet to see how will this impact the code in my projects. But for the evaluation I'd first need `ecdsa` / `p384` to be updated.

cc @tarcieri @dignifiedquire 