### PR TITLE
Linkify code examples in rustdoc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! # Usage
 //!
-//! Using PKCS#1 v1.5.
+//! ## PKCS#1 v1.5 encryption
 //! ```
 //! use rsa::{PublicKey, RsaPrivateKey, RsaPublicKey, PaddingScheme};
 //!
@@ -33,7 +33,7 @@
 //! assert_eq!(&data[..], &dec_data[..]);
 //! ```
 //!
-//! Using OAEP.
+//! ## OAEP encryption
 //! ```
 //! use rsa::{PublicKey, RsaPrivateKey, RsaPublicKey, PaddingScheme};
 //!
@@ -55,7 +55,7 @@
 //! assert_eq!(&data[..], &dec_data[..]);
 //! ```
 //!
-//! Using PKCS#1 v1.5 signatures
+//! ## PKCS#1 v1.5 signatures
 //! ```
 //! use rsa::RsaPrivateKey;
 //! use rsa::pkcs1v15::{SigningKey, VerifyingKey};
@@ -78,7 +78,7 @@
 //! verifying_key.verify(data, &signature).expect("failed to verify");
 //! ```
 //!
-//! Using PSS signatures
+//! ## PSS signatures
 //! ```
 //! use rsa::RsaPrivateKey;
 //! use rsa::pss::{BlindedSigningKey, VerifyingKey};

--- a/src/pkcs1v15.rs
+++ b/src/pkcs1v15.rs
@@ -1,5 +1,9 @@
 //! PKCS#1 v1.5 support as described in [RFC8017 § 8.2].
 //!
+//! # Usage
+//!
+//! See [code example in the toplevel rustdoc](../index.html#pkcs1-v15-signatures).
+//!
 //! [RFC8017 § 8.2]: https://datatracker.ietf.org/doc/html/rfc8017#section-8.2
 
 use alloc::vec::Vec;

--- a/src/pss.rs
+++ b/src/pss.rs
@@ -2,6 +2,10 @@
 //!
 //! Designed by Mihir Bellare and Phillip Rogaway. Specified in [RFC8017 § 8.1].
 //!
+//! # Usage
+//!
+//! See [code example in the toplevel rustdoc](../index.html#pss-signatures).
+//!
 //! [Probabilistic Signature Scheme]: https://en.wikipedia.org/wiki/Probabilistic_signature_scheme
 //! [RFC8017 § 8.1]: https://datatracker.ietf.org/doc/html/rfc8017#section-8.1
 


### PR DESCRIPTION
Makes each code example a linkable section of the rustdoc.

Uses these links to link from individual modules to code examples in the toplevel rustdoc.