### PR TITLE
Make `padding` module private

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,7 +214,6 @@ pub use signature;
 
 pub mod algorithms;
 pub mod errors;
-pub mod padding;
 pub mod pkcs1v15;
 pub mod pss;
 
@@ -222,6 +221,7 @@ mod dummy_rng;
 mod encoding;
 mod key;
 mod oaep;
+mod padding;
 mod raw;
 
 pub use pkcs1;


### PR DESCRIPTION
The only public type in the `padding` module is `PaddingScheme`, which is already re-exported from the toplevel.

There is no rustdoc documentation at the top of the module, and therefore little value in having `PaddingScheme` available as both `rsa::PaddingScheme` and `rsa::padding::PaddingScheme`.