### PR TITLE
Revert "Use namespaced features for `serde`; MSRV 1.60 (#251)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/RustCrypto/RSA"
 keywords = ["rsa", "encryption", "security", "crypto"]
 categories = ["cryptography"]
 readme = "README.md"
-rust-version = "1.60"
+rust-version = "1.57"
 
 [dependencies]
 num-bigint = { version = "0.8.2", features = ["i128", "u64_digit", "prime", "zeroize"], default-features = false, package = "num-bigint-dig" }
@@ -25,7 +25,13 @@ pkcs1 = { version = "0.4", default-features = false, features = ["pkcs8", "alloc
 pkcs8 = { version = "0.9", default-features = false, features = ["alloc"] }
 signature = { version = "2", default-features = false , features = ["digest", "rand_core"] }
 zeroize = { version = "1", features = ["alloc"] }
-serde = { version = "1.0.103", optional = true, default-features = false, features = ["derive"] }
+
+[dependencies.serde_crate]
+package = "serde"
+optional = true
+version = "1.0.103"
+default-features = false
+features = ["derive"]
 
 [dev-dependencies]
 base64ct = { version = "1", features = ["alloc"] }
@@ -45,7 +51,7 @@ name = "key"
 [features]
 default = ["std", "pem"]
 nightly = ["num-bigint/nightly"]
-serde = ["dep:serde", "num-bigint/serde"]
+serde = ["num-bigint/serde", "serde_crate"]
 expose-internals = []
 std = ["digest/std", "pkcs1/std", "pkcs8/std", "rand_core/std", "signature/std"]
 pem = ["pkcs1/pem", "pkcs8/pem"]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![crates.io][crate-image]][crate-link]
 [![Documentation][doc-image]][doc-link]
 [![Build Status][build-image]][build-link]
-![MSRV][msrv-image]
+![minimum rustc 1.57][msrv-image]
 [![Project Chat][chat-image]][chat-link]
 [![dependency status][deps-image]][deps-link]
 
@@ -70,7 +70,7 @@ There will be three phases before `1.0` 🚢 can be released.
 
 ## Minimum Supported Rust Version (MSRV)
 
-All crates in this repository support Rust 1.60 or higher. In future
+All crates in this repository support Rust 1.57 or higher. In future
 minimally supported version of Rust can be changed, but it will be done with
 a minor version bump.
 
@@ -97,7 +97,7 @@ dual licensed as above, without any additional terms or conditions.
 [doc-link]: https://docs.rs/rsa
 [build-image]: https://github.com/rustcrypto/RSA/workflows/CI/badge.svg
 [build-link]: https://github.com/RustCrypto/RSA/actions?query=workflow%3ACI+branch%3Amaster
-[msrv-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.57+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260047-RSA
 [deps-image]: https://deps.rs/repo/github/RustCrypto/RSA/status.svg

--- a/src/key.rs
+++ b/src/key.rs
@@ -6,7 +6,7 @@ use num_bigint::{BigInt, BigUint};
 use num_traits::{One, ToPrimitive};
 use rand_core::CryptoRngCore;
 #[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
+use serde_crate::{Deserialize, Serialize};
 use zeroize::Zeroize;
 
 use crate::algorithms::{generate_multi_prime_key, generate_multi_prime_key_with_exp};
@@ -35,7 +35,11 @@ pub trait PrivateKey: DecryptionPrimitive + PublicKeyParts {}
 
 /// Represents the public part of an RSA key.
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub struct RsaPublicKey {
     n: BigUint,
     e: BigUint,
@@ -43,7 +47,11 @@ pub struct RsaPublicKey {
 
 /// Represents a whole RSA key, public and private parts.
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub struct RsaPrivateKey {
     /// Public components of the private key.
     pubkey_components: RsaPublicKey,


### PR DESCRIPTION
This reverts commit da1997d0b786181f3e3375e3eef09899486a3833.

I was probably over-eager on this: it's a breaking change.

There are probably some non-breaking changes we can make first, and when we're ready to make breaking changes again, we can revert the revert.