### PR TITLE
rsa v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.8.0 (2022-12-17)
+## 0.8.1 (2023-01-20)
+### Added
+- `sha2` feature with `oid` subfeature enabled ([#255])
+
+[#255]: https://github.com/RustCrypto/RSA/pull/255
+
+## 0.8.0 (2023-01-17)
 ### Changed
 - Bump `signature` crate dependency to v2 ([#217], [#249])
 - Switch to `CryptoRngCore` marker trait ([#237])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsa"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["RustCrypto Developers", "dignifiedquire <dignifiedquire@gmail.com>"]
 edition = "2021"
 description = "Pure Rust RSA implementation"


### PR DESCRIPTION
### Added
- `sha2` feature with `oid` subfeature enabled ([#255])

[#255]: https://github.com/RustCrypto/RSA/pull/255