### PR TITLE
Implementation of prime factors recovery

### DIFF
--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -250,7 +250,6 @@ pub fn recover_primes(n: &BigUint, e: &BigUint, d: &BigUint) -> Result<(BigUint,
                 let g = (g - &one) % n;
                 let p = n.gcd(&g);
                 let q = n / &p;
-                std::println!("count: {}", count);
                 return Ok((p, q));
             } else if g_next == n_min1 {
                 continue;

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -207,12 +207,18 @@ fn inc_counter(counter: &mut [u8; 4]) {
     }
 }
 
-/// TODO
-/// Probabilistic algorithm that given `d` returns `p` and `q`
-pub fn recover_primes(n: &BigUint, e: &BigUint, d: &BigUint) -> Result<(BigUint, BigUint)> {
-    const ITER_LIMIT: usize = 100;
+/// Probabilistic algorithm to recover the prime factors of `n` given
+/// `d` and `e` components.
+///
+/// See Appendix C of [NIST-SP-800-56B-r1](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Br1.pdf)
+pub fn recover_primes<R: CryptoRngCore + ?Sized>(
+    rng: &mut R,
+    n: &BigUint,
+    e: &BigUint,
+    d: &BigUint,
+) -> Result<(BigUint, BigUint)> {
     use num_integer::Integer;
-    use rand_core::OsRng;
+    const ITER_LIMIT: usize = 100;
     let one = BigUint::one();
 
     // decompose e·d - 1 in odd and even components: r·2^t
@@ -230,7 +236,7 @@ pub fn recover_primes(n: &BigUint, e: &BigUint, d: &BigUint) -> Result<(BigUint,
     let two = 2_u8.into();
 
     for _ in 0..ITER_LIMIT {
-        let mut g = OsRng.gen_biguint_range(&two, &n);
+        let mut g = rng.gen_biguint_range(&two, &n);
         let q = n.gcd(&g);
         if !q.is_one() {
             // if we are so lucky, we already found a factor.
@@ -268,13 +274,15 @@ mod tests {
 
     #[test]
     fn recover_primes_works() {
+        let mut rng = rand_core::OsRng;
+
         let n = BigUint::parse_bytes(b"00d397b84d98a4c26138ed1b695a8106ead91d553bf06041b62d3fdc50a041e222b8f4529689c1b82c5e71554f5dd69fa2f4b6158cf0dbeb57811a0fc327e1f28e74fe74d3bc166c1eabdc1b8b57b934ca8be5b00b4f29975bcc99acaf415b59bb28a6782bb41a2c3c2976b3c18dbadef62f00c6bb226640095096c0cc60d22fe7ef987d75c6a81b10d96bf292028af110dc7cc1bbc43d22adab379a0cd5d8078cc780ff5cd6209dea34c922cf784f7717e428d75b5aec8ff30e5f0141510766e2e0ab8d473c84e8710b2b98227c3db095337ad3452f19e2b9bfbccdd8148abf6776fa552775e6e75956e45229ae5a9c46949bab1e622f0e48f56524a84ed3483b", 16).unwrap();
         let e = BigUint::from_u64(65537).unwrap();
         let d = BigUint::parse_bytes(b"00c4e70c689162c94c660828191b52b4d8392115df486a9adbe831e458d73958320dc1b755456e93701e9702d76fb0b92f90e01d1fe248153281fe79aa9763a92fae69d8d7ecd144de29fa135bd14f9573e349e45031e3b76982f583003826c552e89a397c1a06bd2163488630d92e8c2bb643d7abef700da95d685c941489a46f54b5316f62b5d2c3a7f1bbd134cb37353a44683fdc9d95d36458de22f6c44057fe74a0a436c4308f73f4da42f35c47ac16a7138d483afc91e41dc3a1127382e0c0f5119b0221b4fc639d6b9c38177a6de9b526ebd88c38d7982c07f98a0efd877d508aae275b946915c02e2e1106d175d74ec6777f5e80d12c053d9c7be1e341", 16).unwrap();
         let p = BigUint::parse_bytes(b"00f827bbf3a41877c7cc59aebf42ed4b29c32defcb8ed96863d5b090a05a8930dd624a21c9dcf9838568fdfa0df65b8462a5f2ac913d6c56f975532bd8e78fb07bd405ca99a484bcf59f019bbddcb3933f2bce706300b4f7b110120c5df9018159067c35da3061a56c8635a52b54273b31271b4311f0795df6021e6355e1a42e61",16).unwrap();
         let q = BigUint::parse_bytes(b"00da4817ce0089dd36f2ade6a3ff410c73ec34bf1b4f6bda38431bfede11cef1f7f6efa70e5f8063a3b1f6e17296ffb15feefa0912a0325b8d1fd65a559e717b5b961ec345072e0ec5203d03441d29af4d64054a04507410cf1da78e7b6119d909ec66e6ad625bf995b279a4b3c5be7d895cd7c5b9c4c497fde730916fcdb4e41b", 16).unwrap();
 
-        let (mut p1, mut q1) = recover_primes(&n, &e, &d).unwrap();
+        let (mut p1, mut q1) = recover_primes(&mut rng, &n, &e, &d).unwrap();
 
         if p1 < q1 {
             std::mem::swap(&mut p1, &mut q1);

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -2,7 +2,7 @@
 
 use digest::{Digest, DynDigest, FixedOutputReset};
 use num_bigint::traits::ModInverse;
-use num_bigint::{BigUint, RandPrime};
+use num_bigint::{BigUint, RandBigInt, RandPrime};
 #[allow(unused_imports)]
 use num_traits::Float;
 use num_traits::{FromPrimitive, One, Zero};
@@ -204,5 +204,83 @@ fn inc_counter(counter: &mut [u8; 4]) {
             // No overflow
             return;
         }
+    }
+}
+
+/// TODO
+/// Probabilistic algorithm that given `d` returns `p` and `q`
+pub fn recover_primes(n: &BigUint, e: &BigUint, d: &BigUint) -> Result<(BigUint, BigUint)> {
+    const ITER_LIMIT: usize = 100;
+    use num_integer::Integer;
+    use rand_core::OsRng;
+    let one = BigUint::one();
+
+    // decompose e·d - 1 in odd and even components: r·2^t
+    let mut r = (e * d) - &one;
+    if r.is_odd() {
+        return Err(Error::InvalidArguments);
+    }
+    let mut t = BigUint::zero();
+    while r.is_even() {
+        t += 1_u8;
+        r >>= 1;
+    }
+
+    let n_min1 = n - &one;
+    let two = 2_u8.into();
+
+    for _ in 0..ITER_LIMIT {
+        let mut g = OsRng.gen_biguint_range(&two, &n);
+        let q = n.gcd(&g);
+        if !q.is_one() {
+            // if we are so lucky, we already found a factor.
+            return Ok((g, q));
+        }
+
+        g = g.modpow(&r, &n);
+        if g.is_one() || g == n_min1 {
+            continue;
+        }
+
+        let mut count = BigUint::one();
+        while count < t {
+            let g_next = g.modpow(&two, n);
+            if g_next.is_one() {
+                // x^2 - 1 = (x-1)(x+1) = 0 (mod n)  then   n | (x-1)(x+1)
+                let g = (g - &one) % n;
+                let p = n.gcd(&g);
+                let q = n / &p;
+                std::println!("count: {}", count);
+                return Ok((p, q));
+            } else if g_next == n_min1 {
+                continue;
+            }
+            g = g_next;
+            count += &one;
+        }
+    }
+
+    Err(Error::InvalidArguments)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recover_primes_works() {
+        let n = BigUint::parse_bytes(b"00d397b84d98a4c26138ed1b695a8106ead91d553bf06041b62d3fdc50a041e222b8f4529689c1b82c5e71554f5dd69fa2f4b6158cf0dbeb57811a0fc327e1f28e74fe74d3bc166c1eabdc1b8b57b934ca8be5b00b4f29975bcc99acaf415b59bb28a6782bb41a2c3c2976b3c18dbadef62f00c6bb226640095096c0cc60d22fe7ef987d75c6a81b10d96bf292028af110dc7cc1bbc43d22adab379a0cd5d8078cc780ff5cd6209dea34c922cf784f7717e428d75b5aec8ff30e5f0141510766e2e0ab8d473c84e8710b2b98227c3db095337ad3452f19e2b9bfbccdd8148abf6776fa552775e6e75956e45229ae5a9c46949bab1e622f0e48f56524a84ed3483b", 16).unwrap();
+        let e = BigUint::from_u64(65537).unwrap();
+        let d = BigUint::parse_bytes(b"00c4e70c689162c94c660828191b52b4d8392115df486a9adbe831e458d73958320dc1b755456e93701e9702d76fb0b92f90e01d1fe248153281fe79aa9763a92fae69d8d7ecd144de29fa135bd14f9573e349e45031e3b76982f583003826c552e89a397c1a06bd2163488630d92e8c2bb643d7abef700da95d685c941489a46f54b5316f62b5d2c3a7f1bbd134cb37353a44683fdc9d95d36458de22f6c44057fe74a0a436c4308f73f4da42f35c47ac16a7138d483afc91e41dc3a1127382e0c0f5119b0221b4fc639d6b9c38177a6de9b526ebd88c38d7982c07f98a0efd877d508aae275b946915c02e2e1106d175d74ec6777f5e80d12c053d9c7be1e341", 16).unwrap();
+        let p = BigUint::parse_bytes(b"00f827bbf3a41877c7cc59aebf42ed4b29c32defcb8ed96863d5b090a05a8930dd624a21c9dcf9838568fdfa0df65b8462a5f2ac913d6c56f975532bd8e78fb07bd405ca99a484bcf59f019bbddcb3933f2bce706300b4f7b110120c5df9018159067c35da3061a56c8635a52b54273b31271b4311f0795df6021e6355e1a42e61",16).unwrap();
+        let q = BigUint::parse_bytes(b"00da4817ce0089dd36f2ade6a3ff410c73ec34bf1b4f6bda38431bfede11cef1f7f6efa70e5f8063a3b1f6e17296ffb15feefa0912a0325b8d1fd65a559e717b5b961ec345072e0ec5203d03441d29af4d64054a04507410cf1da78e7b6119d909ec66e6ad625bf995b279a4b3c5be7d895cd7c5b9c4c497fde730916fcdb4e41b", 16).unwrap();
+
+        let (mut p1, mut q1) = recover_primes(&n, &e, &d).unwrap();
+
+        if p1 < q1 {
+            std::mem::swap(&mut p1, &mut q1);
+        }
+        assert_eq!(p, p1);
+        assert_eq!(q, q1);
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -60,6 +60,9 @@ pub enum Error {
 
     /// Label too long.
     LabelTooLong,
+
+    /// Invalid arguments.
+    InvalidArguments,
 }
 
 #[cfg(feature = "std")]
@@ -87,6 +90,7 @@ impl core::fmt::Display for Error {
             Error::Pkcs8(err) => write!(f, "{}", err),
             Error::Internal => write!(f, "internal error"),
             Error::LabelTooLong => write!(f, "label too long"),
+            Error::InvalidArguments => write!(f, "invalid arguments"),
         }
     }
 }

--- a/src/key.rs
+++ b/src/key.rs
@@ -292,9 +292,10 @@ impl RsaPrivateKey {
             if !primes.is_empty() {
                 return Err(Error::NprimesTooSmall);
             }
-            // Recover `p` and `q` from `d`.
-            // See method in Appendix C: https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Br1.pdf
-            let (p, q) = recover_primes(&n, &e, &d)?;
+            // Recover `p` and `q`
+            // TODO: replace OsRng...
+            let mut rng = rand_core::OsRng;
+            let (p, q) = recover_primes(&mut rng, &n, &e, &d)?;
             primes.push(p);
             primes.push(q);
         }


### PR DESCRIPTION
Implements algorithm described in Appendix C of  https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Br1.pdf

As a first draft, this is using the `rand_core::OsRng` to generate a random number in the range [2, n). 
Obviously this should be replaced somehow. One option is to pass an impl of a PRNG as a parameter, but maybe there is a better solution...

---

Given that:
> According to Fact 1 in [Boneh 1999], the probability that one of the values of y in an
> iteration of Step 3 reveals the factors of the modulus is at least 1/2, so on average, at most
> two iterations of that step will be required

and that:
- *gcd(g, n)  = 1*  (if not we immediately found a factor of n and we've finished...)
- *g^(ed - 1) = 1 (mod n)*  (e and d are valid RSA parameters and this property should hold)
- (e*d - 1) can be decomposed in odd and even factors: r * 2^t  (with r odd)

The only requirement to succeed is to pick a `g` such that:
1. g^(r·k) = 1 (for 1<= k <= 2^t)             <= this is always true when the assumptions above are true
2. g^(r·(k-1)) ≠ -1              

These two requirements are why the probability to succeed with a random `g` is 1/2.
That is, given a sequence of `g^z` (0 <= z <= ed -1) that for sure ends up with 1 at some point we will catch -1 or 1.

If 2 doesn't hold ... we'll try with another `g`.

As an attempt to remove the dependency on a random num generator given the super high probability to catch a correct `g`, maybe we can remove at all the generation of `g` via a proper random number generator and set it to something "good enough" (e.g `g = e · i`, with i =1..100) or something like that...