### PR TITLE
Use namespaced features for `serde`; MSRV 1.60

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.57.0 # MSRV
+          - 1.60.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.57.0 # MSRV
+          - 1.60.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.8.2"
+version = "0.9.0-pre"
 dependencies = [
  "base64ct",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsa"
-version = "0.8.2"
+version = "0.9.0-pre"
 authors = ["RustCrypto Developers", "dignifiedquire <dignifiedquire@gmail.com>"]
 edition = "2021"
 description = "Pure Rust RSA implementation"
@@ -10,7 +10,7 @@ repository = "https://github.com/RustCrypto/RSA"
 keywords = ["rsa", "encryption", "security", "crypto"]
 categories = ["cryptography"]
 readme = "README.md"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [dependencies]
 num-bigint = { version = "0.8.2", features = ["i128", "u64_digit", "prime", "zeroize"], default-features = false, package = "num-bigint-dig" }
@@ -23,21 +23,10 @@ subtle = { version = "2.1.1", default-features = false }
 digest = { version = "0.10.5", default-features = false, features = ["alloc", "oid"] }
 pkcs1 = { version = "0.4", default-features = false, features = ["pkcs8", "alloc"] }
 pkcs8 = { version = "0.9", default-features = false, features = ["alloc"] }
+serde = { version = "1.0.103", optional = true, default-features = false, features = ["derive"] }
+sha2 = { version = "0.10.6", optional = true, default-features = false, features = ["oid"] }
 signature = { version = "2", default-features = false , features = ["digest", "rand_core"] }
 zeroize = { version = "1", features = ["alloc"] }
-
-[dependencies.sha2]
-version = "0.10.6"
-optional = true
-default-features = false
-features = ["oid"]
-
-[dependencies.serde_crate]
-package = "serde"
-optional = true
-version = "1.0.103"
-default-features = false
-features = ["derive"]
 
 [dev-dependencies]
 base64ct = { version = "1", features = ["alloc"] }
@@ -57,7 +46,7 @@ name = "key"
 [features]
 default = ["std", "pem"]
 nightly = ["num-bigint/nightly"]
-serde = ["num-bigint/serde", "serde_crate"]
+serde = ["dep:serde", "num-bigint/serde"]
 expose-internals = []
 std = ["digest/std", "pkcs1/std", "pkcs8/std", "rand_core/std", "signature/std"]
 pem = ["pkcs1/pem", "pkcs8/pem"]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![crates.io][crate-image]][crate-link]
 [![Documentation][doc-image]][doc-link]
 [![Build Status][build-image]][build-link]
-![minimum rustc 1.57][msrv-image]
+![MSRV][msrv-image]
 [![Project Chat][chat-image]][chat-link]
 [![dependency status][deps-image]][deps-link]
 
@@ -70,7 +70,7 @@ There will be three phases before `1.0` 🚢 can be released.
 
 ## Minimum Supported Rust Version (MSRV)
 
-All crates in this repository support Rust 1.57 or higher. In future
+All crates in this repository support Rust 1.60 or higher. In future
 minimally supported version of Rust can be changed, but it will be done with
 a minor version bump.
 
@@ -97,7 +97,7 @@ dual licensed as above, without any additional terms or conditions.
 [doc-link]: https://docs.rs/rsa
 [build-image]: https://github.com/rustcrypto/RSA/workflows/CI/badge.svg
 [build-link]: https://github.com/RustCrypto/RSA/actions?query=workflow%3ACI+branch%3Amaster
-[msrv-image]: https://img.shields.io/badge/rustc-1.57+-blue.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260047-RSA
 [deps-image]: https://deps.rs/repo/github/RustCrypto/RSA/status.svg

--- a/src/key.rs
+++ b/src/key.rs
@@ -6,7 +6,7 @@ use num_bigint::{BigInt, BigUint};
 use num_traits::{One, ToPrimitive};
 use rand_core::CryptoRngCore;
 #[cfg(feature = "serde")]
-use serde_crate::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
 
 use crate::algorithms::{generate_multi_prime_key, generate_multi_prime_key_with_exp};
@@ -35,11 +35,7 @@ pub trait PrivateKey: DecryptionPrimitive + PublicKeyParts {}
 
 /// Represents the public part of an RSA key.
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(Serialize, Deserialize),
-    serde(crate = "serde_crate")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct RsaPublicKey {
     n: BigUint,
     e: BigUint,
@@ -47,11 +43,7 @@ pub struct RsaPublicKey {
 
 /// Represents a whole RSA key, public and private parts.
 #[derive(Debug, Clone)]
-#[cfg_attr(
-    feature = "serde",
-    derive(Serialize, Deserialize),
-    serde(crate = "serde_crate")
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct RsaPrivateKey {
     /// Public components of the private key.
     pubkey_components: RsaPublicKey,


### PR DESCRIPTION
Reverts-the-revert from #254, reinstating #251

This reverts commit 26f38ad66a09fc42ed6d73e3b1864f0251db4e2d.

Since we need to upgrade `pkcs1` and `pkcs8`, which are MSRV 1.65, now is a good time to start making brekaing changes again.