### PR TITLE
pkcs1v15: use `BigUint` as `Signature`'s inner type

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 use num_bigint::BigUint;
 use rand_core::CryptoRngCore;
-use zeroize::Zeroize;
+use zeroize::Zeroizing;
 
 use crate::errors::Result;
 use crate::internals;
@@ -9,7 +9,13 @@ use crate::key::{RsaPrivateKey, RsaPublicKey};
 
 pub trait EncryptionPrimitive {
     /// Do NOT use directly! Only for implementors.
-    fn raw_encryption_primitive(&self, plaintext: &[u8], pad_size: usize) -> Result<Vec<u8>>;
+    fn raw_encryption_primitive(&self, plaintext: &[u8], pad_size: usize) -> Result<Vec<u8>> {
+        let int = Zeroizing::new(BigUint::from_bytes_be(plaintext));
+        self.raw_int_encryption_primitive(&int, pad_size)
+    }
+
+    fn raw_int_encryption_primitive(&self, plaintext: &BigUint, pad_size: usize)
+        -> Result<Vec<u8>>;
 }
 
 pub trait DecryptionPrimitive {
@@ -19,42 +25,40 @@ pub trait DecryptionPrimitive {
         rng: Option<&mut R>,
         ciphertext: &[u8],
         pad_size: usize,
+    ) -> Result<Vec<u8>> {
+        let int = Zeroizing::new(BigUint::from_bytes_be(ciphertext));
+        self.raw_int_decryption_primitive(rng, &int, pad_size)
+    }
+
+    fn raw_int_decryption_primitive<R: CryptoRngCore + ?Sized>(
+        &self,
+        rng: Option<&mut R>,
+        ciphertext: &BigUint,
+        pad_size: usize,
     ) -> Result<Vec<u8>>;
 }
 
 impl EncryptionPrimitive for RsaPublicKey {
-    fn raw_encryption_primitive(&self, plaintext: &[u8], pad_size: usize) -> Result<Vec<u8>> {
-        let mut m = BigUint::from_bytes_be(plaintext);
-        let mut c = internals::encrypt(self, &m);
-        let mut c_bytes = c.to_bytes_be();
-        let ciphertext = internals::left_pad(&c_bytes, pad_size);
-
-        // clear out tmp values
-        m.zeroize();
-        c.zeroize();
-        c_bytes.zeroize();
-
-        ciphertext
+    fn raw_int_encryption_primitive(
+        &self,
+        plaintext: &BigUint,
+        pad_size: usize,
+    ) -> Result<Vec<u8>> {
+        let c = Zeroizing::new(internals::encrypt(self, &plaintext));
+        let c_bytes = Zeroizing::new(c.to_bytes_be());
+        internals::left_pad(&c_bytes, pad_size)
     }
 }
 
 impl DecryptionPrimitive for RsaPrivateKey {
-    fn raw_decryption_primitive<R: CryptoRngCore + ?Sized>(
+    fn raw_int_decryption_primitive<R: CryptoRngCore + ?Sized>(
         &self,
         rng: Option<&mut R>,
-        ciphertext: &[u8],
+        ciphertext: &BigUint,
         pad_size: usize,
     ) -> Result<Vec<u8>> {
-        let mut c = BigUint::from_bytes_be(ciphertext);
-        let mut m = internals::decrypt_and_check(rng, self, &c)?;
-        let mut m_bytes = m.to_bytes_be();
-        let plaintext = internals::left_pad(&m_bytes, pad_size);
-
-        // clear tmp values
-        c.zeroize();
-        m.zeroize();
-        m_bytes.zeroize();
-
-        plaintext
+        let m = Zeroizing::new(internals::decrypt_and_check(rng, self, &ciphertext)?);
+        let m_bytes = Zeroizing::new(m.to_bytes_be());
+        internals::left_pad(&m_bytes, pad_size)
     }
 }


### PR DESCRIPTION
This one half of #220.

Doing anything with a signature involves converting it from bytes into a `BigUint`, so this changes the inner type the latter which is more useful.

It should also help address #272, since it will enable doing those sort of checks more eagerly.

cc @lumag