### PR TITLE
feat: switch to RsaPssParams::new()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs1"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "575fd6eebed721a2929faa1ee1383a49788378083bbbd7f299af75dd84195cee"
+checksum = "4a80397ccad3b40508254eee787bcd28ba48cb82710de5b33cc40c5b2c21bde9"
 dependencies = [
  "der",
  "pkcs8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ byteorder = { version = "1.3.1", default-features = false }
 const-oid = { version = "0.9", default-features = false }
 subtle = { version = "2.1.1", default-features = false }
 digest = { version = "0.10.5", default-features = false, features = ["alloc", "oid"] }
-pkcs1 = { version = "0.7.2", default-features = false, features = ["alloc", "pkcs8"] }
+pkcs1 = { version = "0.7.3", default-features = false, features = ["alloc", "pkcs8"] }
 pkcs8 = { version = "0.10.2", default-features = false, features = ["alloc"] }
 signature = { version = "2", default-features = false , features = ["digest", "rand_core"] }
 zeroize = { version = "1", features = ["alloc"] }

--- a/src/pss.rs
+++ b/src/pss.rs
@@ -20,8 +20,8 @@ use pkcs1::RsaPssParams;
 use pkcs8::{
     spki::{
         der::{Any, AnyRef},
-        AlgorithmIdentifier, AlgorithmIdentifierOwned, AlgorithmIdentifierRef,
-        AssociatedAlgorithmIdentifier, DynSignatureAlgorithmIdentifier,
+        AlgorithmIdentifierOwned, AlgorithmIdentifierRef, AssociatedAlgorithmIdentifier,
+        DynSignatureAlgorithmIdentifier,
     },
     Document, EncodePrivateKey, EncodePublicKey, SecretDocument,
 };
@@ -671,24 +671,9 @@ fn get_pss_signature_algo_id<D>(salt_len: u8) -> pkcs8::spki::Result<AlgorithmId
 where
     D: Digest + AssociatedOid,
 {
-    const ID_MGF_1: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.8");
     const ID_RSASSA_PSS: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.10");
 
-    let pss_params = RsaPssParams {
-        hash: AlgorithmIdentifierRef {
-            oid: D::OID,
-            parameters: None,
-        },
-        mask_gen: AlgorithmIdentifier {
-            oid: ID_MGF_1,
-            parameters: Some(AlgorithmIdentifierRef {
-                oid: D::OID,
-                parameters: None,
-            }),
-        },
-        salt_len,
-        trailer_field: Default::default(),
-    };
+    let pss_params = RsaPssParams::new::<D>(salt_len);
 
     Ok(AlgorithmIdentifierOwned {
         oid: ID_RSASSA_PSS,


### PR DESCRIPTION
Switch to using RsaPssParams::new() from pkcs1 crate. This fixes the issue reported by zlint for x509-cert, where SHA* digest algorithms had empty parameters instead of NULL parameters (as required by Mozilla policy and permitted by RFC4055).