### PR TITLE
Bump `pkcs1` dependency to v0.7.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,14 +268,13 @@ dependencies = [
 
 [[package]]
 name = "pkcs1"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a80397ccad3b40508254eee787bcd28ba48cb82710de5b33cc40c5b2c21bde9"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
  "der",
  "pkcs8",
  "spki",
- "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ byteorder = { version = "1.3.1", default-features = false }
 const-oid = { version = "0.9", default-features = false }
 subtle = { version = "2.1.1", default-features = false }
 digest = { version = "0.10.5", default-features = false, features = ["alloc", "oid"] }
-pkcs1 = { version = "0.7.3", default-features = false, features = ["alloc", "pkcs8"] }
+pkcs1 = { version = "0.7.5", default-features = false, features = ["alloc", "pkcs8"] }
 pkcs8 = { version = "0.10.2", default-features = false, features = ["alloc"] }
 signature = { version = "2", default-features = false , features = ["digest", "rand_core"] }
 zeroize = { version = "1", features = ["alloc"] }


### PR DESCRIPTION
Workaround for RustCrypto/formats#1021