### PR TITLE
Make `PaddingScheme`/`SignatureScheme` object safe

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -14,10 +14,8 @@ use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
 
 use crate::algorithms::generate::generate_multi_prime_key_with_exp;
-use crate::dummy_rng::DummyRng;
 use crate::errors::{Error, Result};
 use crate::keytraits::{CRTValue, PrivateKeyParts, PublicKeyParts};
-
 use crate::padding::{PaddingScheme, SignatureScheme};
 
 /// Represents the public part of an RSA key.
@@ -364,7 +362,7 @@ impl RsaPrivateKey {
 
     /// Decrypt the given message.
     pub fn decrypt<P: PaddingScheme>(&self, padding: P, ciphertext: &[u8]) -> Result<Vec<u8>> {
-        padding.decrypt(Option::<&mut DummyRng>::None, self, ciphertext)
+        padding.decrypt(None, self, ciphertext)
     }
 
     /// Decrypt the given message.
@@ -381,7 +379,7 @@ impl RsaPrivateKey {
 
     /// Sign the given digest.
     pub fn sign<S: SignatureScheme>(&self, padding: S, digest_in: &[u8]) -> Result<Vec<u8>> {
-        padding.sign(Option::<&mut DummyRng>::None, self, digest_in)
+        padding.sign(None, self, digest_in)
     }
 
     /// Sign the given digest using the provided `rng`, which is used in the

--- a/src/oaep.rs
+++ b/src/oaep.rs
@@ -129,9 +129,9 @@ impl Oaep {
 }
 
 impl PaddingScheme for Oaep {
-    fn decrypt<Rng: CryptoRngCore>(
+    fn decrypt(
         mut self,
-        rng: Option<&mut Rng>,
+        rng: Option<&mut dyn CryptoRngCore>,
         priv_key: &RsaPrivateKey,
         ciphertext: &[u8],
     ) -> Result<Vec<u8>> {
@@ -145,9 +145,9 @@ impl PaddingScheme for Oaep {
         )
     }
 
-    fn encrypt<Rng: CryptoRngCore>(
+    fn encrypt(
         mut self,
-        rng: &mut Rng,
+        rng: &mut dyn CryptoRngCore,
         pub_key: &RsaPublicKey,
         msg: &[u8],
     ) -> Result<Vec<u8>> {

--- a/src/padding.rs
+++ b/src/padding.rs
@@ -13,17 +13,17 @@ pub trait PaddingScheme {
     ///
     /// If an `rng` is passed, it uses RSA blinding to help mitigate timing
     /// side-channel attacks.
-    fn decrypt<Rng: CryptoRngCore>(
+    fn decrypt(
         self,
-        rng: Option<&mut Rng>,
+        rng: Option<&mut dyn CryptoRngCore>,
         priv_key: &RsaPrivateKey,
         ciphertext: &[u8],
     ) -> Result<Vec<u8>>;
 
     /// Encrypt the given message using the given public key.
-    fn encrypt<Rng: CryptoRngCore>(
+    fn encrypt(
         self,
-        rng: &mut Rng,
+        rng: &mut dyn CryptoRngCore,
         pub_key: &RsaPublicKey,
         msg: &[u8],
     ) -> Result<Vec<u8>>;
@@ -32,9 +32,9 @@ pub trait PaddingScheme {
 /// Digital signature scheme.
 pub trait SignatureScheme {
     /// Sign the given digest.
-    fn sign<Rng: CryptoRngCore>(
+    fn sign(
         self,
-        rng: Option<&mut Rng>,
+        rng: Option<&mut dyn CryptoRngCore>,
         priv_key: &RsaPrivateKey,
         hashed: &[u8],
     ) -> Result<Vec<u8>>;
@@ -46,4 +46,17 @@ pub trait SignatureScheme {
     ///
     /// If the message is valid `Ok(())` is returned, otherwise an `Err` indicating failure.
     fn verify(self, pub_key: &RsaPublicKey, hashed: &[u8], sig: &[u8]) -> Result<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PaddingScheme, SignatureScheme};
+
+    /// Check object safety
+    #[allow(dead_code)]
+    pub fn padding_scheme_object(_: &dyn PaddingScheme) {}
+
+    /// Check object safety
+    #[allow(dead_code)]
+    pub fn signature_scheme_object(_: &dyn SignatureScheme) {}
 }

--- a/src/pkcs1v15.rs
+++ b/src/pkcs1v15.rs
@@ -42,18 +42,18 @@ use crate::{RsaPrivateKey, RsaPublicKey};
 pub struct Pkcs1v15Encrypt;
 
 impl PaddingScheme for Pkcs1v15Encrypt {
-    fn decrypt<Rng: CryptoRngCore>(
+    fn decrypt(
         self,
-        rng: Option<&mut Rng>,
+        rng: Option<&mut dyn CryptoRngCore>,
         priv_key: &RsaPrivateKey,
         ciphertext: &[u8],
     ) -> Result<Vec<u8>> {
         decrypt(rng, priv_key, ciphertext)
     }
 
-    fn encrypt<Rng: CryptoRngCore>(
+    fn encrypt(
         self,
-        rng: &mut Rng,
+        rng: &mut dyn CryptoRngCore,
         pub_key: &RsaPublicKey,
         msg: &[u8],
     ) -> Result<Vec<u8>> {
@@ -106,9 +106,9 @@ impl Pkcs1v15Sign {
 }
 
 impl SignatureScheme for Pkcs1v15Sign {
-    fn sign<Rng: CryptoRngCore>(
+    fn sign(
         self,
-        rng: Option<&mut Rng>,
+        rng: Option<&mut dyn CryptoRngCore>,
         priv_key: &RsaPrivateKey,
         hashed: &[u8],
     ) -> Result<Vec<u8>> {

--- a/src/pss.rs
+++ b/src/pss.rs
@@ -90,14 +90,14 @@ impl Pss {
 }
 
 impl SignatureScheme for Pss {
-    fn sign<Rng: CryptoRngCore>(
+    fn sign(
         mut self,
-        rng: Option<&mut Rng>,
+        mut rng: Option<&mut dyn CryptoRngCore>,
         priv_key: &RsaPrivateKey,
         hashed: &[u8],
     ) -> Result<Vec<u8>> {
         sign(
-            rng.ok_or(Error::InvalidPaddingScheme)?,
+            rng.as_mut().ok_or(Error::InvalidPaddingScheme)?,
             self.blinded,
             priv_key,
             hashed,


### PR DESCRIPTION
This commit removes the `Rng` generic parameter, replacing it with `dyn CryptoRngCore`.

By eliminating the generic parameter from the signature, the traits become object safe.

This closes #261, which suggested these traits should be object safe. The types that impl these traits were previously a `PaddingScheme` enum which made it easy to select variants at runtime, but that functionality was lost when they were split apart with unifying traits.

Since these traits and the types that impl them effectively represent a "dynamic API" which allows potentially many key usages, making these traits object safe further enables that dynamism.