### PR TITLE
Replace `Deref` impl on `RsaPrivateKey` with `AsRef`

### DIFF
--- a/src/pss.rs
+++ b/src/pss.rs
@@ -405,6 +405,7 @@ mod test {
                 .expect("failed to sign");
 
             priv_key
+                .to_public_key()
                 .verify(Pss::new::<Sha1>(), &digest, &sig)
                 .expect("failed to verify");
         }
@@ -424,6 +425,7 @@ mod test {
                 .expect("failed to sign");
 
             priv_key
+                .to_public_key()
                 .verify(Pss::new::<Sha1>(), &digest, &sig)
                 .expect("failed to verify");
         }
@@ -595,6 +597,7 @@ mod test {
             .expect("failed to sign");
 
         priv_key
+            .to_public_key()
             .verify(Pss::new::<Sha1>(), &digest, &sig)
             .expect("failed to verify");
     }


### PR DESCRIPTION
The `RsaPrivateKey` type previously had a `Deref` impl providing access to the associated `RsaPublicKey`.

`Deref` is intended for "smart pointer types", i.e. container types which manage a (typically generic) inner type in some way. This doesn't seem like one of those cases.

`AsRef`, on the other hand, is for cheap reference conversions, which is exactly what's happening here, so it's a better fit and provides the same functionality (albeit explicitly rather than via deref coercion).