### PR TITLE
v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,60 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.0 (2023-04-27)
+### Added
+- Function to get salt length from RSA PSS keys ([#277])
+- `AssociatedAlgorithmIdentifier` implementation ([#278])
+- Random key generation for `pss::BlindedSigningKey` ([#295])
+- Impl `Signer` for `pss::SigningKey` ([#297])
+- Impl `core::hash::Hash` for `RsaPrivateKey` ([#308])
+- Impl `ZeroizeOnDrop` for `RsaPrivateKey`, `SigningKey`, `DecryptingKey` ([#311])
+- `u64_digit` feature; on-by-default ([#313])
+- `AsRef<RsaPublicKey>` impl on `RsaPrivateKey` ([#317])
+
+### Changed
+- Use namespaced features for `serde` ([#268])
+- Bump `pkcs1` to v0.7, `pkcs8` to v0.10; MSRV 1.65 ([#270])
+- Rename PKCS#1v1.5 `*_with_prefix` methods ([#290])
+  - `SigningKey::new` => `SigningKey::new_unprefixed`
+  - `SigningKey::new_with_prefix` => `SigningKey::new`
+  - `VerifyingKey::new` => `VerifyingKey::new_unprefixed`
+  - `VerifyingKey::new_with_prefix` => `VerifyingKey::new`
+- Rename `Pkcs1v15Sign::new_raw` to `Pkcs1v15Sign::new_unprefixed` ([#293])
+- Use digest output size as default PSS salt length ([#294])
+- Specify `salt_len` when verifying PSS signatures ([#294])
+- Ensure signatures have the expected length and don't overflow the modulus ([#306])
+- Improved public key checks ([#307])
+- Rename `CRTValue` => `CrtValue` ([#314])
+- Traits under `padding` module now located under `traits` module ([#315])
+- `PublicKeyParts`/`PrivateKeyParts` now located under `traits` module ([#315])
+
+### Removed
+- "Unsalted" PSS support ([#294])
+- `EncryptionPrimitive`/`DecriptionPrimitive` traits ([#300])
+- `PublicKey`/`PrivateKey` traits ([#300])
+- `Zeroize` impl on `RsaPrivateKey`; automatically zeroized on drop ([#311])
+- `Deref<Target=RsaPublicKey>` impl on `RsaPrivateKey`; use `AsRef` instead ([#317])
+
+[#268]: https://github.com/RustCrypto/RSA/pull/268
+[#270]: https://github.com/RustCrypto/RSA/pull/270
+[#277]: https://github.com/RustCrypto/RSA/pull/277
+[#278]: https://github.com/RustCrypto/RSA/pull/278
+[#290]: https://github.com/RustCrypto/RSA/pull/290
+[#293]: https://github.com/RustCrypto/RSA/pull/293
+[#294]: https://github.com/RustCrypto/RSA/pull/294
+[#295]: https://github.com/RustCrypto/RSA/pull/295
+[#297]: https://github.com/RustCrypto/RSA/pull/297
+[#300]: https://github.com/RustCrypto/RSA/pull/300
+[#306]: https://github.com/RustCrypto/RSA/pull/306
+[#307]: https://github.com/RustCrypto/RSA/pull/307
+[#308]: https://github.com/RustCrypto/RSA/pull/308
+[#311]: https://github.com/RustCrypto/RSA/pull/311
+[#313]: https://github.com/RustCrypto/RSA/pull/313
+[#314]: https://github.com/RustCrypto/RSA/pull/314
+[#315]: https://github.com/RustCrypto/RSA/pull/315
+[#317]: https://github.com/RustCrypto/RSA/pull/317
+
 ## 0.8.2 (2023-03-01)
 ### Added
 - Encryption-related traits ([#259])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.0-rc.0"
+version = "0.9.0"
 dependencies = [
  "base64ct",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsa"
-version = "0.9.0-rc.0"
+version = "0.9.0"
 authors = ["RustCrypto Developers", "dignifiedquire <dignifiedquire@gmail.com>"]
 edition = "2021"
 description = "Pure Rust RSA implementation"

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ There will be three phases before `1.0` 🚢 can be released.
 This crate has received one [security audit by Include Security][audit], with
 only one minor finding which has since been addressed.
 
+See the [open security issues] on our issue tracker for other known problems.
+
 ## Minimum Supported Rust Version (MSRV)
 
 All crates in this repository support Rust 1.65 or higher.
@@ -109,3 +111,4 @@ dual licensed as above, without any additional terms or conditions.
 
 [RustCrypto]: https://github.com/RustCrypto/
 [audit]: https://www.opentech.fund/results/security-safety-audits/deltachat/
+[open security issues]: https://github.com/RustCrypto/RSA/issues?q=is%3Aissue+is%3Aopen+label%3Asecurity

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,38 +4,18 @@
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 #![warn(missing_docs)]
 
-//! RSA Implementation in pure Rust.
+//! # Supported algorithms
 //!
-//! It supports several schemes described in [RFC8017]:
+//! This crate supports several schemes described in [RFC8017]:
 //!
-//! - OAEP encryption scheme
-//! - PKCS#1 v1.5 encryption scheme
-//! - PKCS#1 v1.5 signature scheme
-//! - PSS signature scheme
+//! - [OAEP encryption scheme](#oaep-encryption)
+//! - [PKCS#1 v1.5 encryption scheme](#pkcs1-v15-encryption)
+//! - [PKCS#1 v1.5 signature scheme](#pkcs1-v15-signatures)
+//! - [PSS signature scheme](#pss-signatures)
 //!
 //! These schemes are described below.
 //!
 //! # Usage
-//!
-//! ## PKCS#1 v1.5 encryption
-//! ```
-//! use rsa::{RsaPrivateKey, RsaPublicKey, Pkcs1v15Encrypt};
-//!
-//! let mut rng = rand::thread_rng();
-//!
-//! let bits = 2048;
-//! let private_key = RsaPrivateKey::new(&mut rng, bits).expect("failed to generate a key");
-//! let public_key = RsaPublicKey::from(&private_key);
-//!
-//! // Encrypt
-//! let data = b"hello world";
-//! let enc_data = public_key.encrypt(&mut rng, Pkcs1v15Encrypt, &data[..]).expect("failed to encrypt");
-//! assert_ne!(&data[..], &enc_data[..]);
-//!
-//! // Decrypt
-//! let dec_data = private_key.decrypt(Pkcs1v15Encrypt, &enc_data).expect("failed to decrypt");
-//! assert_eq!(&data[..], &dec_data[..]);
-//! ```
 //!
 //! ## OAEP encryption
 //! ```
@@ -56,6 +36,26 @@
 //! // Decrypt
 //! let padding = Oaep::new::<sha2::Sha256>();
 //! let dec_data = private_key.decrypt(padding, &enc_data).expect("failed to decrypt");
+//! assert_eq!(&data[..], &dec_data[..]);
+//! ```
+//!
+//! ## PKCS#1 v1.5 encryption
+//! ```
+//! use rsa::{RsaPrivateKey, RsaPublicKey, Pkcs1v15Encrypt};
+//!
+//! let mut rng = rand::thread_rng();
+//!
+//! let bits = 2048;
+//! let private_key = RsaPrivateKey::new(&mut rng, bits).expect("failed to generate a key");
+//! let public_key = RsaPublicKey::from(&private_key);
+//!
+//! // Encrypt
+//! let data = b"hello world";
+//! let enc_data = public_key.encrypt(&mut rng, Pkcs1v15Encrypt, &data[..]).expect("failed to encrypt");
+//! assert_ne!(&data[..], &enc_data[..]);
+//!
+//! // Decrypt
+//! let dec_data = private_key.decrypt(Pkcs1v15Encrypt, &enc_data).expect("failed to decrypt");
 //! assert_eq!(&data[..], &dec_data[..]);
 //! ```
 //!


### PR DESCRIPTION
### Added
- Function to get salt length from RSA PSS keys ([#277])
- `AssociatedAlgorithmIdentifier` implementation ([#278])
- Random key generation for `pss::BlindedSigningKey` ([#295])
- Impl `Signer` for `pss::SigningKey` ([#297])
- Impl `core::hash::Hash` for `RsaPrivateKey` ([#308])
- Impl `ZeroizeOnDrop` for `RsaPrivateKey`, `SigningKey`, `DecryptingKey` ([#311])
- `u64_digit` feature; on-by-default ([#313])
- `AsRef<RsaPublicKey>` impl on `RsaPrivateKey` ([#317])

### Changed
- Use namespaced features for `serde` ([#268])
- Bump `pkcs1` to v0.7, `pkcs8` to v0.10; MSRV 1.65 ([#270])
- Rename PKCS#1v1.5 `*_with_prefix` methods ([#290])
  - `SigningKey::new` => `SigningKey::new_unprefixed`
  - `SigningKey::new_with_prefix` => `SigningKey::new`
  - `VerifyingKey::new` => `VerifyingKey::new_unprefixed`
  - `VerifyingKey::new_with_prefix` => `VerifyingKey::new`
- Rename `Pkcs1v15Sign::new_raw` to `Pkcs1v15Sign::new_unprefixed` ([#293])
- Use digest output size as default PSS salt length ([#294])
- Specify `salt_len` when verifying PSS signatures ([#294])
- Ensure signatures have the expected length and don't overflow the modulus ([#306])
- Improved public key checks ([#307])
- Rename `CRTValue` => `CrtValue` ([#314])
- Traits under `padding` module now located under `traits` module ([#315])
- `PublicKeyParts`/`PrivateKeyParts` now located under `traits` module ([#315])

### Removed
- "Unsalted" PSS support ([#294])
- `EncryptionPrimitive`/`DecriptionPrimitive` traits ([#300])
- `PublicKey`/`PrivateKey` traits ([#300])
- `Zeroize` impl on `RsaPrivateKey`; automatically zeroized on drop ([#311])
- `Deref<Target=RsaPublicKey>` impl on `RsaPrivateKey`; use `AsRef` instead ([#317])

[#268]: https://github.com/RustCrypto/RSA/pull/268
[#270]: https://github.com/RustCrypto/RSA/pull/270
[#277]: https://github.com/RustCrypto/RSA/pull/277
[#278]: https://github.com/RustCrypto/RSA/pull/278
[#290]: https://github.com/RustCrypto/RSA/pull/290
[#293]: https://github.com/RustCrypto/RSA/pull/293
[#294]: https://github.com/RustCrypto/RSA/pull/294
[#295]: https://github.com/RustCrypto/RSA/pull/295
[#297]: https://github.com/RustCrypto/RSA/pull/297
[#300]: https://github.com/RustCrypto/RSA/pull/300
[#306]: https://github.com/RustCrypto/RSA/pull/306
[#307]: https://github.com/RustCrypto/RSA/pull/307
[#308]: https://github.com/RustCrypto/RSA/pull/308
[#311]: https://github.com/RustCrypto/RSA/pull/311
[#313]: https://github.com/RustCrypto/RSA/pull/313
[#314]: https://github.com/RustCrypto/RSA/pull/314
[#315]: https://github.com/RustCrypto/RSA/pull/315
[#317]: https://github.com/RustCrypto/RSA/pull/317