### PR TITLE
pkcs1v15: note `RSASSA-PKCS1-v1_5` in docs

### DIFF
--- a/src/pkcs1v15.rs
+++ b/src/pkcs1v15.rs
@@ -56,7 +56,7 @@ impl PaddingScheme for Pkcs1v15Encrypt {
     }
 }
 
-/// Digital signatures using PKCS#1 v1.5 padding.
+/// `RSASSA-PKCS1-v1_5`: digital signatures using PKCS#1 v1.5 padding.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Pkcs1v15Sign {
     /// Length of hash to use.

--- a/src/pkcs1v15/signature.rs
+++ b/src/pkcs1v15/signature.rs
@@ -8,7 +8,7 @@ use alloc::{boxed::Box, string::ToString};
 use core::fmt::{Debug, Display, Formatter, LowerHex, UpperHex};
 use num_bigint::BigUint;
 
-/// PKCS#1 v1.5 signatures as described in [RFC8017 § 8.2].
+/// `RSASSA-PKCS1-v1_5` signatures as described in [RFC8017 § 8.2].
 ///
 /// [RFC8017 § 8.2]: https://datatracker.ietf.org/doc/html/rfc8017#section-8.2
 #[derive(Clone, PartialEq, Eq)]

--- a/src/pkcs1v15/signing_key.rs
+++ b/src/pkcs1v15/signing_key.rs
@@ -16,7 +16,7 @@ use signature::{
 };
 use zeroize::ZeroizeOnDrop;
 
-/// Signing key for PKCS#1 v1.5 signatures as described in [RFC8017 § 8.2].
+/// Signing key for `RSASSA-PKCS1-v1_5` signatures as described in [RFC8017 § 8.2].
 ///
 /// [RFC8017 § 8.2]: https://datatracker.ietf.org/doc/html/rfc8017#section-8.2
 #[derive(Debug, Clone)]

--- a/src/pkcs1v15/verifying_key.rs
+++ b/src/pkcs1v15/verifying_key.rs
@@ -12,7 +12,7 @@ use pkcs8::{
 };
 use signature::{hazmat::PrehashVerifier, DigestVerifier, Verifier};
 
-/// Verifying key for PKCS#1 v1.5 signatures as described in [RFC8017 § 8.2].
+/// Verifying key for `RSASSA-PKCS1-v1_5` signatures as described in [RFC8017 § 8.2].
 ///
 /// [RFC8017 § 8.2]: https://datatracker.ietf.org/doc/html/rfc8017#section-8.2
 #[derive(Debug)]


### PR DESCRIPTION
This is the name for PKCS#1v1.5 signatures originally specified in RFC3447 but is also used by RFC8017 (which we cite)