### PR TITLE
pkcs1v15: have `fmt` impls call `SignatureEncoding::to_bytes`

### DIFF
--- a/src/pkcs1v15/signature.rs
+++ b/src/pkcs1v15/signature.rs
@@ -61,13 +61,19 @@ impl Debug for Signature {
 
 impl LowerHex for Signature {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{:x}", &self.inner)
+        for byte in self.to_bytes().iter() {
+            write!(f, "{:02x}", byte)?;
+        }
+        Ok(())
     }
 }
 
 impl UpperHex for Signature {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{:X}", &self.inner)
+        for byte in self.to_bytes().iter() {
+            write!(f, "{:02X}", byte)?;
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
The `fmt::{LowerHex, UpperHex}` impls, with the latter called vicariously via `fmt::Display`, were showing the unpadded signature rather than the padded one.

This changes these impls to call `SignatureEncoding::to_bytes` first before displaying the signature.