### PR TITLE
v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.2 (2023-05-08)
+### Fixed
+- pkcs1v15: have `fmt` impls call `SignatureEncoding::to_bytes` ([#330])
+
+[#330]: https://github.com/RustCrypto/RSA/pull/330
+
 ## 0.9.1 (2023-05-03)
 ### Fixed
 - Left pad signatures when encoding ([#325])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,7 +512,7 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "rsa"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "base64ct",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsa"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["RustCrypto Developers", "dignifiedquire <dignifiedquire@gmail.com>"]
 edition = "2021"
 description = "Pure Rust RSA implementation"


### PR DESCRIPTION
### Fixed
- pkcs1v15: have `fmt` impls call `SignatureEncoding::to_bytes` ([#330])

[#330]: https://github.com/RustCrypto/RSA/pull/330