### PR TITLE
Set min version of serde to 1.0.184

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## UNRELEASED
-### Changed
-- Pin upper version of `serde` to <1.0.172 to work around [serde-rs/serde#2538] ([#359])
-
-[#359]: https://github.com/RustCrypto/RSA/pull/359
-[serde-rs/serde#2538]: https://github.com/serde-rs/serde/issues/2538
-
 ## 0.9.2 (2023-05-08)
 ### Fixed
 - pkcs1v15: have `fmt` impls call `SignatureEncoding::to_bytes` ([#330])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "libc",
 ]
@@ -559,18 +559,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,7 @@ zeroize = { version = "1.5", features = ["alloc"] }
 # optional dependencies
 sha1 = { version = "0.10.5", optional = true, default-features = false, features = ["oid"] }
 sha2 = { version = "0.10.6", optional = true, default-features = false, features = ["oid"] }
-# Pin upper version of serde to work around https://github.com/serde-rs/serde/issues/2538
-serde = { version = "1.0.103, <1.0.172", optional = true, default-features = false, features = ["derive"] }
+serde = { version = "1.0.184", optional = true, default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 base64ct = { version = "1", features = ["alloc"] }


### PR DESCRIPTION
In 1.0.184 `serde` was [un-blobbed](https://github.com/serde-rs/serde/releases/tag/v1.0.184). To prevent accidental pulling of the blobbed versions 1.0.184 will be used as a min version.

Relevant PR: #359 