### PR TITLE
v0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.3 (2023-10-26)
+### Added
+- PKCS#8/SPKI decoding trait impls for `pkcs1v15` keys ([#346])
+- `hazmat` feature as a replacement for `expose-internals` ([#352])
+
+### Changed
+- Bump `serde` dependency to 1.0.184 ([#360])
+
+### Removed
+- Unused dependencies ([#357])
+
+[#346]: https://github.com/RustCrypto/RSA/pull/346
+[#352]: https://github.com/RustCrypto/RSA/pull/352
+[#357]: https://github.com/RustCrypto/RSA/pull/357
+[#360]: https://github.com/RustCrypto/RSA/pull/360
+
 ## 0.9.2 (2023-05-08)
 ### Fixed
 - pkcs1v15: have `fmt` impls call `SignatureEncoding::to_bytes` ([#330])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,7 +485,7 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "rsa"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "base64ct",
  "const-oid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsa"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["RustCrypto Developers", "dignifiedquire <dignifiedquire@gmail.com>"]
 edition = "2021"
 description = "Pure Rust RSA implementation"


### PR DESCRIPTION
### Added
- PKCS#8/SPKI decoding trait impls for `pkcs1v15` keys ([#346])
- `hazmat` feature as a replacement for `expose-internals` ([#352])

### Changed
- Bump `serde` dependency to 1.0.184 ([#360])

### Removed
- Unused dependencies ([#357])

[#346]: https://github.com/RustCrypto/RSA/pull/346
[#352]: https://github.com/RustCrypto/RSA/pull/352
[#357]: https://github.com/RustCrypto/RSA/pull/357
[#360]: https://github.com/RustCrypto/RSA/pull/360