### PR TITLE
CI: pin nightly; test minimal-versions on stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly
+      - uses: dtolnay/rust-toolchain@nightly
       - run: cargo update -Z minimal-versions
+      - uses: dtolnay/rust-toolchain@stable
       - run: cargo test --release --features getrandom,serde,pkcs5
 
   nightly:
@@ -76,6 +75,6 @@ jobs:
       - uses: RustCrypto/actions/cargo-cache@master
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly
+          toolchain: nightly-2023-10-01
       - run: cargo test --release --features nightly
       - run: cargo build --benches


### PR DESCRIPTION
- Pins to nightly-2023-10-01 to prevent regressions
- On `minimal-versions` only uses nightly to resolve versions, and runs tests on stable instead

This is a workaround for build failures we're seeing due to a recent nightly regression. See:

https://github.com/RustCrypto/RSA/actions/runs/6655788342/job/18086838437?pr=377

https://github.com/RustCrypto/RSA/actions/runs/6655788342/job/18086838800?pr=377
