### PR TITLE
Revert "README.md: use `? instead of `expect` in example (#385)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,24 +12,21 @@ A portable RSA implementation in pure Rust.
 ## Example
 
 ```rust
-# fn main() -> Result<(), rsa::Error> {
 use rsa::{Pkcs1v15Encrypt, RsaPrivateKey, RsaPublicKey};
 
 let mut rng = rand::thread_rng();
 let bits = 2048;
-let priv_key = RsaPrivateKey::new(&mut rng, bits)?;
+let priv_key = RsaPrivateKey::new(&mut rng, bits).expect("failed to generate a key");
 let pub_key = RsaPublicKey::from(&priv_key);
 
 // Encrypt
 let data = b"hello world";
-let enc_data = pub_key.encrypt(&mut rng, Pkcs1v15Encrypt, &data[..])?;
+let enc_data = pub_key.encrypt(&mut rng, Pkcs1v15Encrypt, &data[..]).expect("failed to encrypt");
 assert_ne!(&data[..], &enc_data[..]);
 
 // Decrypt
-let dec_data = priv_key.decrypt(Pkcs1v15Encrypt, &enc_data)?;
+let dec_data = priv_key.decrypt(Pkcs1v15Encrypt, &enc_data).expect("failed to decrypt");
 assert_eq!(&data[..], &dec_data[..]);
-# Ok(())
-# }
 ```
 
 > **Note:** If you encounter unusually slow key generation time while using `RsaPrivateKey::new` you can try to compile in release mode or add the following to your `Cargo.toml`. Key generation is much faster when building with higher optimization levels, but this will increase the compile time a bit.


### PR DESCRIPTION
This reverts commit 00eaa91db598ad6ebe57024182e93bb82c3d75a3.

Unfortunately while `#` comments work in rustdoc, they are visible when GitHub renders the README.md, so this doesn't work.