### PR TITLE
pkcs1v15: expose `RsaSignatureAssociatedOid`

### DIFF
--- a/src/pkcs1v15.rs
+++ b/src/pkcs1v15.rs
@@ -222,7 +222,7 @@ mod oid {
     use const_oid::ObjectIdentifier;
 
     /// A trait which associates an RSA-specific OID with a type.
-    pub(crate) trait RsaSignatureAssociatedOid {
+    pub trait RsaSignatureAssociatedOid {
         /// The OID associated with this type.
         const OID: ObjectIdentifier;
     }
@@ -257,6 +257,8 @@ mod oid {
             const_oid::ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.13");
     }
 }
+
+pub use oid::RsaSignatureAssociatedOid;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This allows reuse of the `RsaSignatureAssociatedOid` trait to pull implementation of `SignatureAlgorithmIdentifier` in other crates (like [`yubihsm.rs`](https://github.com/iqlusioninc/yubihsm.rs/blob/eab46209f236043a9cbaa6568c0b4d0e8cc8244b/src/rsa/pkcs1/signer.rs#L87)).