### PR TITLE
v0.9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.6 (2023-12-01)
+### Added
+- expose a `pss::get_default_pss_signature_algo_id` helper ([#393])
+- expose `pkcs1v15::RsaSignatureAssociatedOid` ([#392])
+
+[#392]: https://github.com/RustCrypto/RSA/pull/392
+[#393]: https://github.com/RustCrypto/RSA/pull/393
+
 ## 0.9.5 (2023-11-27)
 ### Added
 - Adds `RsaPrivateKey::from_primes` and `RsaPrivateKey::from_p_q` methods ([#386])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,7 +465,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rsa"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "base64ct",
  "const-oid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsa"
-version = "0.9.5"
+version = "0.9.6"
 authors = ["RustCrypto Developers", "dignifiedquire <dignifiedquire@gmail.com>"]
 edition = "2021"
 description = "Pure Rust RSA implementation"


### PR DESCRIPTION
Added
 - expose a `pss::get_default_pss_signature_algo_id` helper ([#393])
 - expose `pkcs1v15::RsaSignatureAssociatedOid` ([#392])