### PR TITLE
Bump version to v0.10.0-pre

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsa"
-version = "0.9.6"
+version = "0.10.0-pre"
 authors = ["RustCrypto Developers", "dignifiedquire <dignifiedquire@gmail.com>"]
 edition = "2021"
 description = "Pure Rust RSA implementation"


### PR DESCRIPTION
NOTE: not for release.

This signifies that we are going to make breaking changes to the `master` branch which are incompatible with v0.9 releases.

The first prerelease of this series published to crates.io will be v0.10.0-pre.0 at some point in the future.