### PR TITLE
Fix unused import warnings

### DIFF
--- a/src/pkcs1v15/signature.rs
+++ b/src/pkcs1v15/signature.rs
@@ -1,17 +1,14 @@
-pub use ::signature::{
-    hazmat::{PrehashSigner, PrehashVerifier},
-    DigestSigner, DigestVerifier, Error, Keypair, RandomizedDigestSigner, RandomizedSigner, Result,
-    SignatureEncoding, Signer, Verifier,
-};
+//! `RSASSA-PKCS1-v1_5` signatures.
+
+use crate::algorithms::pad::uint_to_be_pad;
+use ::signature::SignatureEncoding;
+use alloc::{boxed::Box, string::ToString};
+use core::fmt::{Debug, Display, Formatter, LowerHex, UpperHex};
+use num_bigint::BigUint;
 use spki::{
     der::{asn1::BitString, Result as DerResult},
     SignatureBitStringEncoding,
 };
-
-use crate::algorithms::pad::uint_to_be_pad;
-use alloc::{boxed::Box, string::ToString};
-use core::fmt::{Debug, Display, Formatter, LowerHex, UpperHex};
-use num_bigint::BigUint;
 
 /// `RSASSA-PKCS1-v1_5` signatures as described in [RFC8017 § 8.2].
 ///

--- a/src/pss/signature.rs
+++ b/src/pss/signature.rs
@@ -1,19 +1,16 @@
-pub use ::signature::{
-    hazmat::{PrehashSigner, PrehashVerifier},
-    DigestSigner, DigestVerifier, Error, Keypair, RandomizedDigestSigner, RandomizedSigner, Result,
-    SignatureEncoding, Signer, Verifier,
-};
+//! `RSASSA-PSS` signatures.
+
+use crate::algorithms::pad::uint_to_be_pad;
+use ::signature::SignatureEncoding;
+use alloc::{boxed::Box, string::ToString};
+use core::fmt::{Debug, Display, Formatter, LowerHex, UpperHex};
+use num_bigint::BigUint;
 use spki::{
     der::{asn1::BitString, Result as DerResult},
     SignatureBitStringEncoding,
 };
 
-use crate::algorithms::pad::uint_to_be_pad;
-use alloc::{boxed::Box, string::ToString};
-use core::fmt::{Debug, Display, Formatter, LowerHex, UpperHex};
-use num_bigint::BigUint;
-
-/// RSASSA-PSS signatures as described in [RFC8017 § 8.1].
+/// `RSASSA-PSS` signatures as described in [RFC8017 § 8.1].
 ///
 /// [RFC8017 § 8.1]: https://datatracker.ietf.org/doc/html/rfc8017#section-8.1
 #[derive(Clone, PartialEq, Eq)]


### PR DESCRIPTION
Newer versions of rustc report these. They were previously ignored because they were `pub use`, but inside of a non-`pub` module.