### PR TITLE
Bump format/signature dependencies to prereleases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.72.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.11.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edadbde8e0243b49d434f9a23ec0590af201f400a34d7d51049284e4a77c568"
+dependencies = [
+ "crypto-common 0.2.0-pre.4",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,15 +106,15 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "inout",
 ]
 
 [[package]]
 name = "const-oid"
-version = "0.9.5"
+version = "0.10.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+checksum = "f7e3352a27098ba6b09546e5f13b15165e6a88b5c2723afecb3ea9576b27e3ea"
 
 [[package]]
 name = "cpufeatures"
@@ -127,10 +136,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.7.8"
+name = "crypto-common"
+version = "0.2.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+checksum = "806e4e3731d44f1340b069551225b44c2056c105cad9e67f0c46266db8a3a6b9"
+dependencies = [
+ "getrandom",
+ "hybrid-array",
+ "rand_core",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b489fd2221710c1dd46637d66b984161fb66134f81437a8489800306bcc2ecea"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -143,10 +163,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.0-pre.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957713a19ffdda287c63772e607f848512f67ba948f17d8e42cb8d50fd98a786"
+dependencies = [
+ "block-buffer 0.11.0-pre.4",
+ "const-oid",
+ "crypto-common 0.2.0-pre.4",
 ]
 
 [[package]]
@@ -204,7 +234,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.2.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b700a69c9d992339e82b6cda619873ee17768be06e80ed5ef07c50c50d499ab"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -219,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.4"
+version = "0.2.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
+checksum = "a7cdd4f0dc5807b9a2b25dd48a3f58e862606fe7bd47f41ecde36e97422d7e90"
 dependencies = [
  "cpufeatures",
 ]
@@ -308,24 +347,24 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
 ]
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.7.0"
+version = "1.0.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+checksum = "76a65e1c27d1680f8805b3f8c9949f08d6aa5d6cbd088c9896e64a53821dc27d"
 dependencies = [
  "base64ct",
 ]
 
 [[package]]
 name = "pkcs1"
-version = "0.7.5"
+version = "0.8.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+checksum = "4f6af6e88ac39402f67488e22faa9eb15cf065f520cf4a09419393691a6d0133"
 dependencies = [
  "der",
  "pkcs8",
@@ -334,24 +373,24 @@ dependencies = [
 
 [[package]]
 name = "pkcs5"
-version = "0.7.1"
+version = "0.8.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
+checksum = "2c6aebdab8ec0fe71f347de8d37212be79ccdedeb0f46133b0cf2bc5f6d2c65a"
 dependencies = [
  "aes",
  "cbc",
  "der",
  "pbkdf2",
  "scrypt",
- "sha2",
+ "sha2 0.10.8",
  "spki",
 ]
 
 [[package]]
 name = "pkcs8"
-version = "0.10.2"
+version = "0.11.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+checksum = "935c09e0aecb0cb8f8907b57438b19a068cb74a25189b06724f061170b2465ff"
 dependencies = [
  "der",
  "pkcs5",
@@ -465,11 +504,11 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rsa"
-version = "0.9.6"
+version = "0.10.0-pre"
 dependencies = [
  "base64ct",
  "const-oid",
- "digest",
+ "digest 0.11.0-pre.7",
  "hex-literal",
  "num-bigint-dig",
  "num-integer",
@@ -484,7 +523,7 @@ dependencies = [
  "serde",
  "serde_test",
  "sha1",
- "sha2",
+ "sha2 0.11.0-pre.2",
  "sha3",
  "signature",
  "spki",
@@ -534,7 +573,7 @@ checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
 dependencies = [
  "pbkdf2",
  "salsa20",
- "sha2",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -568,13 +607,13 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.11.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "301ed48dd873557d86a1843ebcdd511b628f13ec5401a0efa7007dc5a595eb1f"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.11.0-pre.7",
 ]
 
 [[package]]
@@ -585,26 +624,37 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0-pre.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e18b939d4051b69874cbdb8f55de6a14ae44b357ccb94bdbd0a2122f8f875a46"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.11.0-pre.7",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.11.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "9cecb44e361133b3304a1b3e325a1d8c999339fec8c19762b55e1509a17d6806"
 dependencies = [
- "digest",
+ "digest 0.11.0-pre.7",
  "keccak",
 ]
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "2.3.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+checksum = "017ea2f120415e4bf9c6177425b40386f207284147564e19d196c7bc90483c08"
 dependencies = [
- "digest",
+ "digest 0.11.0-pre.7",
  "rand_core",
 ]
 
@@ -622,9 +672,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
-version = "0.7.3"
+version = "0.8.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+checksum = "cb2b56670f5ef52934c97efad30bf42585de0c33ec3e2a886e38b80d2db67243"
 dependencies = [
  "base64ct",
  "der",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,25 +10,25 @@ repository = "https://github.com/RustCrypto/RSA"
 keywords = ["rsa", "encryption", "security", "crypto"]
 categories = ["cryptography"]
 readme = "README.md"
-rust-version = "1.65"
+rust-version = "1.72"
 
 [dependencies]
 num-bigint = { version = "0.8.2", features = ["i128", "prime", "zeroize"], default-features = false, package = "num-bigint-dig" }
 num-traits = { version= "0.2.9", default-features = false, features = ["libm"] }
 num-integer = { version = "0.1.39", default-features = false }
 rand_core = { version = "0.6.4", default-features = false }
-const-oid = { version = "0.9", default-features = false }
+const-oid = { version = "=0.10.0-pre.2", default-features = false }
 subtle = { version = "2.1.1", default-features = false }
-digest = { version = "0.10.5", default-features = false, features = ["alloc", "oid"] }
-pkcs1 = { version = "0.7.5", default-features = false, features = ["alloc", "pkcs8"] }
-pkcs8 = { version = "0.10.2", default-features = false, features = ["alloc"] }
-signature = { version = ">2.0, <2.3", default-features = false , features = ["alloc", "digest", "rand_core"] }
-spki = { version = "0.7.3", default-features = false, features = ["alloc"] }
+digest = { version = "=0.11.0-pre.7", default-features = false, features = ["alloc", "oid"] }
+pkcs1 = { version = "=0.8.0-pre.0", default-features = false, features = ["alloc", "pkcs8"] }
+pkcs8 = { version = "=0.11.0-pre.0", default-features = false, features = ["alloc"] }
+signature = { version = "=2.3.0-pre.2", default-features = false , features = ["alloc", "digest", "rand_core"] }
+spki = { version = "=0.8.0-pre.0", default-features = false, features = ["alloc"] }
 zeroize = { version = "1.5", features = ["alloc"] }
 
 # optional dependencies
-sha1 = { version = "0.10.5", optional = true, default-features = false, features = ["oid"] }
-sha2 = { version = "0.10.6", optional = true, default-features = false, features = ["oid"] }
+sha1 = { version = "=0.11.0-pre.2", optional = true, default-features = false, features = ["oid"] }
+sha2 = { version = "=0.11.0-pre.2", optional = true, default-features = false, features = ["oid"] }
 serde = { version = "1.0.184", optional = true, default-features = false, features = ["derive"] }
 
 [dev-dependencies]
@@ -40,9 +40,9 @@ rand_xorshift = "0.3"
 rand_chacha = "0.3"
 rand = "0.8"
 rand_core = { version = "0.6", default-features = false }
-sha1 = { version = "0.10.5", default-features = false, features = ["oid"] }
-sha2 = { version = "0.10.6", default-features = false, features = ["oid"] }
-sha3 = { version = "0.10.7", default-features = false, features = ["oid"] }
+sha1 = { version = "=0.11.0-pre.2", default-features = false, features = ["oid"] }
+sha2 = { version = "=0.11.0-pre.2", default-features = false, features = ["oid"] }
+sha3 = { version = "=0.11.0-pre.2", default-features = false, features = ["oid"] }
 
 [[bench]]
 name = "key"

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ You can follow our work on mitigating this issue in [#390].
 
 ## Minimum Supported Rust Version (MSRV)
 
-All crates in this repository support Rust 1.65 or higher.
+This crate supports Rust 1.72 or higher.
 
 In the future MSRV can be changed, but it will be done with a minor version bump.
 
@@ -108,7 +108,7 @@ dual licensed as above, without any additional terms or conditions.
 [doc-link]: https://docs.rs/rsa
 [build-image]: https://github.com/rustcrypto/RSA/workflows/CI/badge.svg
 [build-link]: https://github.com/RustCrypto/RSA/actions?query=workflow%3ACI+branch%3Amaster
-[msrv-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260047-RSA
 [deps-image]: https://deps.rs/repo/github/RustCrypto/RSA/status.svg


### PR DESCRIPTION
This makes it possible to use `rsa` with prerelease versions of `x509-cert`.

Bumps the following dependencies:

- `const-oid` v0.10.0-pre.2
- `digest` v0.11.0-pre.7
- `pkcs1` v0.8.0-pre.0
- `pkcs8` v0.11.0-pre.0
- `signature` v2.3.0-pre.2
- `sha1` v0.11.0-pre.2
- `sha2` v0.11.0-pre.2
- `sha3` v0.11.0-pre.2
- `spki` v0.8.0-pre.0