### PR TITLE
serdect for RsaPublicKey, RsaPrivateKey and pkcs1v15 types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,6 +263,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
 name = "keccak"
 version = "0.2.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,9 +418,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -441,9 +453,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -521,7 +533,9 @@ dependencies = [
  "rand_core",
  "rand_xorshift",
  "serde",
+ "serde_json",
  "serde_test",
+ "serdect",
  "sha1",
  "sha2 0.11.0-pre.3",
  "sha3",
@@ -557,6 +571,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+
+[[package]]
 name = "salsa20"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,22 +598,33 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.192"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.192"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -602,6 +633,16 @@ version = "1.0.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a2f49ace1498612d14f7e0b8245519584db8299541dfe31a06374a828d620ab"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
  "serde",
 ]
 
@@ -688,9 +729,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,12 +263,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
-
-[[package]]
 name = "keccak"
 version = "0.2.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,7 +527,6 @@ dependencies = [
  "rand_core",
  "rand_xorshift",
  "serde",
- "serde_json",
  "serde_test",
  "serdect",
  "sha1",
@@ -569,12 +562,6 @@ dependencies = [
  "tempfile",
  "wait-timeout",
 ]
-
-[[package]]
-name = "ryu"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "salsa20"
@@ -614,17 +601,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.114"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ serde = { version = "1.0.184", optional = true, default-features = false, featur
 
 [dev-dependencies]
 base64ct = { version = "1", features = ["alloc"] }
-serde_json = "1.0.114"
 hex-literal = "0.4.1"
 proptest = "1"
 serde_test = "1.0.89"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ pkcs8 = { version = "=0.11.0-pre.0", default-features = false, features = ["allo
 signature = { version = "=2.3.0-pre.3", default-features = false , features = ["alloc", "digest", "rand_core"] }
 spki = { version = "=0.8.0-pre.0", default-features = false, features = ["alloc"] }
 zeroize = { version = "1.5", features = ["alloc"] }
+serdect = "0.2.0"
 
 # optional dependencies
 sha1 = { version = "=0.11.0-pre.3", optional = true, default-features = false, features = ["oid"] }
@@ -33,6 +34,7 @@ serde = { version = "1.0.184", optional = true, default-features = false, featur
 
 [dev-dependencies]
 base64ct = { version = "1", features = ["alloc"] }
+serde_json = "1.0.114"
 hex-literal = "0.4.1"
 proptest = "1"
 serde_test = "1.0.89"

--- a/src/pkcs1v15/decrypting_key.rs
+++ b/src/pkcs1v15/decrypting_key.rs
@@ -4,6 +4,8 @@ use crate::{
     traits::{Decryptor, EncryptingKeypair, RandomizedDecryptor},
     Result, RsaPrivateKey,
 };
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use alloc::vec::Vec;
 use rand_core::CryptoRngCore;
 use zeroize::ZeroizeOnDrop;
@@ -12,6 +14,7 @@ use zeroize::ZeroizeOnDrop;
 ///
 /// [RFC8017 § 7.2]: https://datatracker.ietf.org/doc/html/rfc8017#section-7.2
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DecryptingKey {
     inner: RsaPrivateKey,
 }

--- a/src/pkcs1v15/encrypting_key.rs
+++ b/src/pkcs1v15/encrypting_key.rs
@@ -1,12 +1,15 @@
 use super::encrypt;
 use crate::{traits::RandomizedEncryptor, Result, RsaPublicKey};
 use alloc::vec::Vec;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use rand_core::CryptoRngCore;
 
 /// Encryption key for PKCS#1 v1.5 encryption as described in [RFC8017 § 7.2].
 ///
 /// [RFC8017 § 7.2]: https://datatracker.ietf.org/doc/html/rfc8017#section-7.2
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct EncryptingKey {
     pub(super) inner: RsaPublicKey,
 }

--- a/src/pkcs1v15/signature.rs
+++ b/src/pkcs1v15/signature.rs
@@ -3,6 +3,8 @@
 use crate::algorithms::pad::uint_to_be_pad;
 use ::signature::SignatureEncoding;
 use alloc::{boxed::Box, string::ToString};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use core::fmt::{Debug, Display, Formatter, LowerHex, UpperHex};
 use num_bigint::BigUint;
 use spki::{
@@ -14,6 +16,7 @@ use spki::{
 ///
 /// [RFC8017 § 8.2]: https://datatracker.ietf.org/doc/html/rfc8017#section-8.2
 #[derive(Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Signature {
     pub(super) inner: BigUint,
     pub(super) len: usize,

--- a/src/pkcs1v15/signature.rs
+++ b/src/pkcs1v15/signature.rs
@@ -16,7 +16,6 @@ use spki::{
 ///
 /// [RFC8017 § 8.2]: https://datatracker.ietf.org/doc/html/rfc8017#section-8.2
 #[derive(Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Signature {
     pub(super) inner: BigUint,
     pub(super) len: usize,

--- a/src/pkcs1v15/signing_key.rs
+++ b/src/pkcs1v15/signing_key.rs
@@ -3,6 +3,8 @@ use crate::{dummy_rng::DummyRng, Result, RsaPrivateKey};
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 use digest::Digest;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use pkcs8::{
     spki::{
         der::AnyRef, AlgorithmIdentifierRef, AssociatedAlgorithmIdentifier,
@@ -20,6 +22,7 @@ use zeroize::ZeroizeOnDrop;
 ///
 /// [RFC8017 § 8.2]: https://datatracker.ietf.org/doc/html/rfc8017#section-8.2
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SigningKey<D>
 where
     D: Digest,

--- a/src/pkcs1v15/verifying_key.rs
+++ b/src/pkcs1v15/verifying_key.rs
@@ -3,6 +3,8 @@ use crate::RsaPublicKey;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 use digest::Digest;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use pkcs8::{
     spki::{
         der::AnyRef, AlgorithmIdentifierRef, AssociatedAlgorithmIdentifier,
@@ -16,6 +18,7 @@ use signature::{hazmat::PrehashVerifier, DigestVerifier, Verifier};
 ///
 /// [RFC8017 § 8.2]: https://datatracker.ietf.org/doc/html/rfc8017#section-8.2
 #[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct VerifyingKey<D>
 where
     D: Digest,


### PR DESCRIPTION
`RsaPublicKey` and `RsaPrivateKey` now use `serdect`. 
In `pkcs1v15` the types: `Signature`, `SigningKey`, `EncryptingKey`, `DecryptingKey` and `VerifyingKey` use `serdect`.
(`DecryptingKey` and `EncryptingKey` are wrappers for `RsaPrivateKey` and `RsaPublicKey` so they just use the underlying `serdect` implementation).