### PR TITLE
fix: remove oaep decrypt key size limit (#418)

### DIFF
--- a/src/oaep.rs
+++ b/src/oaep.rs
@@ -240,8 +240,6 @@ fn decrypt<R: CryptoRngCore + ?Sized>(
     mgf_digest: &mut dyn DynDigest,
     label: Option<String>,
 ) -> Result<Vec<u8>> {
-    key::check_public(priv_key)?;
-
     if ciphertext.len() != priv_key.size() {
         return Err(Error::Decryption);
     }


### PR DESCRIPTION
As per #418, let me know if this is the preferred way or if you'd rather remove the limit some other way