### PR TITLE
pss: expose salt len in the verifyingkey

### DIFF
--- a/src/pss/verifying_key.rs
+++ b/src/pss/verifying_key.rs
@@ -46,6 +46,11 @@ where
             phantom: Default::default(),
         }
     }
+
+    /// Return specified salt length for this key
+    pub fn salt_len(&self) -> usize {
+        self.salt_len
+    }
 }
 
 //


### PR DESCRIPTION
Some vendor serialization (NDA :() of signature and public keys will need the size of the salt that was used for signature. Sadly this is only exposed in the signing key (which may be out of reach (HSM)).