### PR TITLE
feat: add uncheck_modulus_size feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ pem = ["pkcs1/pem", "pkcs8/pem"]
 pkcs5 = ["pkcs8/encryption"]
 u64_digit = ["num-bigint/u64_digit"]
 std = ["digest/std", "pkcs1/std", "pkcs8/std", "rand_core/std", "signature/std"]
+uncheck_modulus_size = []
 
 [package.metadata.docs.rs]
 features = ["std", "pem", "serde", "hazmat", "sha2"]

--- a/src/key.rs
+++ b/src/key.rs
@@ -504,6 +504,7 @@ pub fn check_public(public_key: &impl PublicKeyParts) -> Result<()> {
 /// Check that the public key is well formed and has an exponent within acceptable bounds.
 #[inline]
 fn check_public_with_max_size(public_key: &impl PublicKeyParts, max_size: usize) -> Result<()> {
+    #[cfg(not(feature = "uncheck_modulus_size"))]
     if public_key.n().bits() > max_size {
         return Err(Error::ModulusTooLarge);
     }

--- a/src/key.rs
+++ b/src/key.rs
@@ -508,6 +508,8 @@ fn check_public_with_max_size(public_key: &impl PublicKeyParts, max_size: usize)
     if public_key.n().bits() > max_size {
         return Err(Error::ModulusTooLarge);
     }
+    #[cfg(feature = "uncheck_modulus_size")]
+    let _unused = max_size;
 
     let e = public_key
         .e()


### PR DESCRIPTION
Same to #418, some projects use a modulus size larger than 4096. And the source code may be written in C++ or Java.
There are still some issues when using the decrypt method, for example, Pkcs1v15Encrypt::decrypt.

Therefore, I have implemented a feature called `uncheck_modulus_size`, hoping it will be useful for others.