### PR TITLE
oaep: support non-string labels

### DIFF
--- a/src/oaep/encrypting_key.rs
+++ b/src/oaep/encrypting_key.rs
@@ -1,9 +1,6 @@
 use super::encrypt_digest;
 use crate::{traits::RandomizedEncryptor, Result, RsaPublicKey};
-use alloc::{
-    string::{String, ToString},
-    vec::Vec,
-};
+use alloc::{boxed::Box, vec::Vec};
 use core::marker::PhantomData;
 use digest::{Digest, FixedOutputReset};
 use rand_core::CryptoRngCore;
@@ -21,7 +18,7 @@ where
     MGD: Digest + FixedOutputReset,
 {
     inner: RsaPublicKey,
-    label: Option<String>,
+    label: Option<Box<[u8]>>,
     phantom: PhantomData<D>,
     mg_phantom: PhantomData<MGD>,
 }
@@ -42,10 +39,10 @@ where
     }
 
     /// Create a new verifying key from an RSA public key using provided label
-    pub fn new_with_label<S: AsRef<str>>(key: RsaPublicKey, label: S) -> Self {
+    pub fn new_with_label<S: Into<Box<[u8]>>>(key: RsaPublicKey, label: S) -> Self {
         Self {
             inner: key,
-            label: Some(label.as_ref().to_string()),
+            label: Some(label.into()),
             phantom: Default::default(),
             mg_phantom: Default::default(),
         }
@@ -62,7 +59,7 @@ where
         rng: &mut R,
         msg: &[u8],
     ) -> Result<Vec<u8>> {
-        encrypt_digest::<_, D, MGD>(rng, &self.inner, msg, self.label.as_ref().cloned())
+        encrypt_digest::<_, D, MGD>(rng, &self.inner, msg, self.label.clone())
     }
 }
 


### PR DESCRIPTION
This rework oaep to support non-string labels.
One use-case is encryption of secrets in TPM.

https://trustedcomputinggroup.org/wp-content/uploads/TPM-2.0-1.83-Part-1-Architecture.pdf#page=297
Section B.4 RSAES_OAEP
```
For RSA keys protecting a secret value (such as, an encryption key or a session secret), the L parameter
is a byte stream, the last byte of which must be zero, indicating the intended use of the encrypted value. 
```

That would look like:
```rust
    let encrypted_seed = {
        let padding = Oaep::new_with_label::<EkHash, _>(b"IDENTITY\0".to_vec());
        let enc_data = ek_public
            .encrypt(&mut rng, padding, &random_seed[..])
            .expect("failed to encrypt");
        enc_data
    };
 ```