### PR TITLE
pkcs1v15: change `VerifyingKey::from` to use prefixed version

### DIFF
--- a/src/pkcs1v15/verifying_key.rs
+++ b/src/pkcs1v15/verifying_key.rs
@@ -170,10 +170,10 @@ where
 
 impl<D> From<RsaPublicKey> for VerifyingKey<D>
 where
-    D: Digest,
+    D: Digest + AssociatedOid,
 {
     fn from(key: RsaPublicKey) -> Self {
-        Self::new_unprefixed(key)
+        Self::new(key)
     }
 }
 


### PR DESCRIPTION
As discussed in #341, `pkcs1v15::VerifyingKey::from` should use the prefixed keys.

Just lost a couple hours on this one behavior, and since 0.10 is just around the corner, might as well fix it before that.

Fixes #341