### PR TITLE
add comment to specify the rand version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,7 +465,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rsa"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "base64ct",
  "const-oid",

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A portable RSA implementation in pure Rust.
 ```rust
 use rsa::{Pkcs1v15Encrypt, RsaPrivateKey, RsaPublicKey};
 
-let mut rng = rand::thread_rng();
+let mut rng = rand::thread_rng(); // rand@0.8
 let bits = 2048;
 let priv_key = RsaPrivateKey::new(&mut rng, bits).expect("failed to generate a key");
 let pub_key = RsaPublicKey::from(&priv_key);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 #![cfg_attr(not(feature = "sha2"), doc = "```ignore")]
 //! use rsa::{RsaPrivateKey, RsaPublicKey, Oaep, sha2::Sha256};
 //!
-//! let mut rng = rand::thread_rng();
+//! let mut rng = rand::thread_rng(); // rand@0.8
 //!
 //! let bits = 2048;
 //! let private_key = RsaPrivateKey::new(&mut rng, bits).expect("failed to generate a key");
@@ -47,7 +47,7 @@
 //! ```
 //! use rsa::{RsaPrivateKey, RsaPublicKey, Pkcs1v15Encrypt};
 //!
-//! let mut rng = rand::thread_rng();
+//! let mut rng = rand::thread_rng(); // rand@0.8
 //!
 //! let bits = 2048;
 //! let private_key = RsaPrivateKey::new(&mut rng, bits).expect("failed to generate a key");
@@ -74,7 +74,7 @@
 //! use rsa::signature::{Keypair, RandomizedSigner, SignatureEncoding, Verifier};
 //! use rsa::sha2::{Digest, Sha256};
 //!
-//! let mut rng = rand::thread_rng();
+//! let mut rng = rand::thread_rng(); // rand@0.8
 //!
 //! let bits = 2048;
 //! let private_key = RsaPrivateKey::new(&mut rng, bits).expect("failed to generate a key");
@@ -101,7 +101,7 @@
 //! use rsa::signature::{Keypair,RandomizedSigner, SignatureEncoding, Verifier};
 //! use rsa::sha2::{Digest, Sha256};
 //!
-//! let mut rng = rand::thread_rng();
+//! let mut rng = rand::thread_rng(); // rand@0.8
 //!
 //! let bits = 2048;
 //! let private_key = RsaPrivateKey::new(&mut rng, bits).expect("failed to generate a key");

--- a/src/oaep.rs
+++ b/src/oaep.rs
@@ -61,7 +61,7 @@ impl Oaep {
     /// let n = Base64::decode_vec("ALHgDoZmBQIx+jTmgeeHW6KsPOrj11f6CvWsiRleJlQpW77AwSZhd21ZDmlTKfaIHBSUxRUsuYNh7E2SHx8rkFVCQA2/gXkZ5GK2IUbzSTio9qXA25MWHvVxjMfKSL8ZAxZyKbrG94FLLszFAFOaiLLY8ECs7g+dXOriYtBwLUJK+lppbd+El+8ZA/zH0bk7vbqph5pIoiWggxwdq3mEz4LnrUln7r6dagSQzYErKewY8GADVpXcq5mfHC1xF2DFBub7bFjMVM5fHq7RK+pG5xjNDiYITbhLYrbVv3X0z75OvN0dY49ITWjM7xyvMWJXVJS7sJlgmCCL6RwWgP8PhcE=").unwrap();
     /// let e = Base64::decode_vec("AQAB").unwrap();
     ///
-    /// let mut rng = rand::thread_rng();
+    /// let mut rng = rand::thread_rng(); // rand@0.8
     /// let key = RsaPublicKey::new(BigUint::from_bytes_be(&n), BigUint::from_bytes_be(&e)).unwrap();
     /// let padding = Oaep::new::<Sha256>();
     /// let encrypted_data = key.encrypt(&mut rng, padding, b"secret").unwrap();
@@ -98,7 +98,7 @@ impl Oaep {
     /// let n = Base64::decode_vec("ALHgDoZmBQIx+jTmgeeHW6KsPOrj11f6CvWsiRleJlQpW77AwSZhd21ZDmlTKfaIHBSUxRUsuYNh7E2SHx8rkFVCQA2/gXkZ5GK2IUbzSTio9qXA25MWHvVxjMfKSL8ZAxZyKbrG94FLLszFAFOaiLLY8ECs7g+dXOriYtBwLUJK+lppbd+El+8ZA/zH0bk7vbqph5pIoiWggxwdq3mEz4LnrUln7r6dagSQzYErKewY8GADVpXcq5mfHC1xF2DFBub7bFjMVM5fHq7RK+pG5xjNDiYITbhLYrbVv3X0z75OvN0dY49ITWjM7xyvMWJXVJS7sJlgmCCL6RwWgP8PhcE=").unwrap();
     /// let e = Base64::decode_vec("AQAB").unwrap();
     ///
-    /// let mut rng = rand::thread_rng();
+    /// let mut rng = rand::thread_rng(); // rand@0.8
     /// let key = RsaPublicKey::new(BigUint::from_bytes_be(&n), BigUint::from_bytes_be(&e)).unwrap();
     /// let padding = Oaep::new_with_mgf_hash::<Sha256, Sha1>();
     /// let encrypted_data = key.encrypt(&mut rng, padding, b"secret").unwrap();

--- a/src/pkcs1v15/signature.rs
+++ b/src/pkcs1v15/signature.rs
@@ -1,8 +1,4 @@
-pub use ::signature::{
-    hazmat::{PrehashSigner, PrehashVerifier},
-    DigestSigner, DigestVerifier, Error, Keypair, RandomizedDigestSigner, RandomizedSigner, Result,
-    SignatureEncoding, Signer, Verifier,
-};
+pub use ::signature::SignatureEncoding;
 use spki::{
     der::{asn1::BitString, Result as DerResult},
     SignatureBitStringEncoding,

--- a/src/pss/signature.rs
+++ b/src/pss/signature.rs
@@ -1,8 +1,4 @@
-pub use ::signature::{
-    hazmat::{PrehashSigner, PrehashVerifier},
-    DigestSigner, DigestVerifier, Error, Keypair, RandomizedDigestSigner, RandomizedSigner, Result,
-    SignatureEncoding, Signer, Verifier,
-};
+pub use ::signature::SignatureEncoding;
 use spki::{
     der::{asn1::BitString, Result as DerResult},
     SignatureBitStringEncoding,


### PR DESCRIPTION
Hello,

This PR is not super useful BUT can be useful.

Of course this PR should be kind of reversed/updated when the rand 0.9 will be supported

Linked to 
- https://github.com/RustCrypto/RSA/issues/466
- https://github.com/RustCrypto/traits/issues/1642
- https://rustcrypto.zulipchat.com/#narrow/channel/260047-RSA/topic/rand.20dependencies/near/499002018

Feel free to close if not useful enough to be merged