### PR TITLE
v0.10.0-pre.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rsa"
-version = "0.10.0-pre.3"
+version = "0.10.0-pre.4"
 dependencies = [
  "base64ct",
  "const-oid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsa"
-version = "0.10.0-pre.3"
+version = "0.10.0-pre.4"
 authors = ["RustCrypto Developers", "dignifiedquire <dignifiedquire@gmail.com>"]
 edition = "2021"
 description = "Pure Rust RSA implementation"


### PR DESCRIPTION
Notably includes #394 which migrates to `crypto-bigint`