### PR TITLE
Document specific version requirement of rand for compiling example code in README.me

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ assert_ne!(&data[..], &enc_data[..]);
 let dec_data = priv_key.decrypt(Pkcs1v15Encrypt, &enc_data).expect("failed to decrypt");
 assert_eq!(&data[..], &dec_data[..]);
 ```
+`Cargo.toml`
+```toml
+[dependencies]
+rand = "0.8.0"
+```
 
 > **Note:** If you encounter unusually slow key generation time while using `RsaPrivateKey::new` you can try to compile in release mode or add the following to your `Cargo.toml`. Key generation is much faster when building with higher optimization levels, but this will increase the compile time a bit.
 > ```toml


### PR DESCRIPTION
The example code provided does not compile using the latest version of rand (0.9). Simply documenting this in the README should reduce some headache in the mean time before #466 has be solved.
