### PR TITLE
Rename `getrandom` crate feature to `os_rng`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,8 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack test --release --feature-powerset --exclude-features getrandom,serde
-      - run: cargo test --release --features getrandom
+      - run: cargo hack test --release --feature-powerset --exclude-features os_rng,serde
+      - run: cargo test --release --features os_rng
       - run: cargo test --release --features serde
 
   minimal-versions:
@@ -61,7 +61,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
       - run: cargo update -Z minimal-versions
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo test --release --features getrandom,serde,pkcs5
+      - run: cargo test --release --features os_rng,serde,pkcs5
 
   nightly:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ name = "key"
 [features]
 default = ["std", "pem"]
 hazmat = []
-getrandom = ["rand_core/os_rng", "crypto-bigint/rand_core"]
+os_rng = ["rand_core/os_rng", "crypto-bigint/rand_core"]
 serde = ["dep:serde", "dep:serdect", "crypto-bigint/serde"]
 pem = ["pkcs1/pem", "pkcs8/pem"]
 pkcs5 = ["pkcs8/encryption"]

--- a/src/pss/signing_key.rs
+++ b/src/pss/signing_key.rs
@@ -22,7 +22,7 @@ use {
     serdect::serde::{de, ser, Deserialize, Serialize},
 };
 
-#[cfg(feature = "getrandom")]
+#[cfg(feature = "os_rng")]
 use {
     rand_core::OsRng,
     signature::{hazmat::PrehashSigner, Signer},
@@ -133,7 +133,7 @@ where
     }
 }
 
-#[cfg(feature = "getrandom")]
+#[cfg(feature = "os_rng")]
 impl<D> PrehashSigner<Signature> for SigningKey<D>
 where
     D: Digest + FixedOutputReset,
@@ -143,7 +143,7 @@ where
     }
 }
 
-#[cfg(feature = "getrandom")]
+#[cfg(feature = "os_rng")]
 impl<D> Signer<Signature> for SigningKey<D>
 where
     D: Digest + FixedOutputReset,


### PR DESCRIPTION
Follows the renaming in the `rand_core` crate.