### PR TITLE
changelog: add entries for v0.9.7 and v0.9.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.9.7 (2024-11-26)
 ### Fixed
-- always validate keys in from_components
-- do not crash when handling tiny keys in PKCS1v15
+- Always validate keys in `RsaPrivateKey::from_components` ([#459])
+- Do not crash when handling tiny keys in PKCS1v15 ([#459])
+
+[#459]: https://github.com/RustCrypto/RSA/pull/459
 
 ## 0.9.6 (2023-12-01)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.8 (2025-03-12)
+### Added
+- Doc comments to specify the `rand` version ([#473])
+
+[#473]: https://github.com/RustCrypto/RSA/pull/473
+
+## 0.9.7 (2024-11-26)
+### Fixed
+- always validate keys in from_components
+- do not crash when handling tiny keys in PKCS1v15
+
 ## 0.9.6 (2023-12-01)
 ### Added
 - expose a `pss::get_default_pss_signature_algo_id` helper ([#393])


### PR DESCRIPTION
These versions were published as part of the `0-9-x` backport branch.