### PR TITLE
use a public url for git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "thirdparty/wycheproof"]
 	path = thirdparty/wycheproof
-	url = git@github.com:C2SP/wycheproof
+	url = https://github.com/C2SP/wycheproof.git


### PR DESCRIPTION
When pulling `RSA` with a `[patch.crates-io]`, the CI runner doesn't carry an SSH key with github and fails to clone the submodules.

This changes the `git@github.com` to an `https://github.com` to allow anonymous clones.