### PR TITLE
Version hint for sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A portable RSA implementation in pure Rust.
 ```rust
 use rsa::{Pkcs1v15Encrypt, RsaPrivateKey, RsaPublicKey};
 
-let mut rng = rand::thread_rng();
+let mut rng = rand::thread_rng(); // rand crate should be version 0.8
 let bits = 2048;
 let priv_key = RsaPrivateKey::new(&mut rng, bits).expect("failed to generate a key");
 let pub_key = RsaPublicKey::from(&priv_key);


### PR DESCRIPTION
The sample doesn't compile with the latest version of the rand crate, it needs to be version 0.8. This adds a hint to remember to change the version to prevent confusion. It could also have been added somewhere else on the README, but this way people who copied the example see it in their editor next to the problematic variable.
- #213