### PR TITLE
chore(deps): bump `crypto-bigint` to `0.7.0-pre.3`; use core naming conventions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-pre.2"
+version = "0.7.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a5061ea0870b06f7fdd5a0f7268e30c04de1932c148cca0ce5c79a88d18bed"
+checksum = "f727d84cf16cb51297e4388421e2e51b2f94ffe92ee1d8664d81676901196fa3"
 dependencies = [
  "num-traits",
  "rand_core 0.9.3",
@@ -158,9 +158,10 @@ dependencies = [
 [[package]]
 name = "crypto-primes"
 version = "0.7.0-dev"
-source = "git+https://github.com/entropyxyz/crypto-primes.git#541a5eb1c05664385aaff2697faf72c7200a9786"
+source = "git+https://github.com/entropyxyz/crypto-primes.git#04f927401b9eed948d4d26d149064cc292fea72e"
 dependencies = [
  "crypto-bigint",
+ "libm",
  "rand_core 0.9.3",
 ]
 
@@ -319,6 +320,12 @@ name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "linux-raw-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ pkcs8 = { version = "0.11.0-rc.2", default-features = false, features = ["alloc"
 signature = { version = "=3.0.0-pre", default-features = false, features = ["alloc", "digest", "rand_core"] }
 spki = { version = "0.8.0-rc.1", default-features = false, features = ["alloc"] }
 zeroize = { version = "1.5", features = ["alloc"] }
-crypto-bigint = { version = "0.7.0-pre.2", default-features = false, features = ["zeroize", "alloc"] }
+crypto-bigint = { version = "0.7.0-pre.3", default-features = false, features = ["zeroize", "alloc"] }
 crypto-primes = { version = "0.7.0-dev", default-features = false }
 
 # optional dependencies

--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -190,7 +190,7 @@ fn blind<R: TryCryptoRng + ?Sized, K: PublicKeyParts>(
         }
 
         // r^-1 (mod n)
-        ir = r.inv_mod(key.n()).into();
+        ir = r.invert_mod(key.n()).into();
     }
 
     let blinded = {
@@ -348,7 +348,7 @@ pub(crate) fn compute_private_exponent_euler_totient(
 
     // NOTE: `mod_inverse` checks if `exp` evenly divides `totient` and returns `None` if so.
     // This ensures that `exp` is not a factor of any `(prime - 1)`.
-    match exp.inv_mod(&totient).into_option() {
+    match exp.invert_mod(&totient).into_option() {
         Some(res) => Ok(res),
         None => Err(Error::InvalidPrime),
     }
@@ -376,7 +376,7 @@ pub(crate) fn compute_private_exponent_carmicheal(
     let gcd = p1.gcd(&q1);
     let lcm = p1 / NonZero::new(gcd).expect("gcd is non zero") * &q1;
     let exp = exp.resize_unchecked(lcm.bits_precision());
-    if let Some(d) = exp.inv_mod(&lcm).into() {
+    if let Some(d) = exp.invert_mod(&lcm).into() {
         Ok(d)
     } else {
         // `exp` evenly divides `lcm`

--- a/src/key.rs
+++ b/src/key.rs
@@ -497,7 +497,7 @@ impl RsaPrivateKey {
         let p = &self.primes[0];
         let q = &self.primes[1];
 
-        Option::from(q.inv_mod(p))
+        Option::from(q.invert_mod(p))
     }
 
     /// Performs basic sanity checks on the key.


### PR DESCRIPTION
See:
 - https://github.com/RustCrypto/crypto-bigint/pull/817