### PR TITLE
PublicKeyParts: provide serialization helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,8 +136,7 @@ dependencies = [
 [[package]]
 name = "crypto-bigint"
 version = "0.7.0-pre.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f727d84cf16cb51297e4388421e2e51b2f94ffe92ee1d8664d81676901196fa3"
+source = "git+https://github.com/RustCrypto/crypto-bigint.git#38df76241f943e70951c3a814abfabc9ac965dd3"
 dependencies = [
  "num-traits",
  "rand_core 0.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,3 +85,6 @@ pkcs8 = { git = "https://github.com/RustCrypto/formats.git" }
 # https://github.com/RustCrypto/password-hashes/pull/578
 pbkdf2 = { git = "https://github.com/baloo/password-hashes.git", branch = "baloo/hmac-0.13.0-pre.5" }
 scrypt = { git = "https://github.com/baloo/password-hashes.git", branch = "baloo/hmac-0.13.0-pre.5" }
+
+# https://github.com/RustCrypto/crypto-bigint/pull/824
+crypto-bigint = { git = "https://github.com/RustCrypto/crypto-bigint.git" }

--- a/src/key.rs
+++ b/src/key.rs
@@ -718,6 +718,8 @@ mod tests {
         let n_limbs: &[u64] = PublicKeyParts::n(&public_key).as_ref().as_ref();
         assert_eq!(n_limbs, &[101u64]);
         assert_eq!(PublicKeyParts::e(&public_key), &BoxedUint::from(200u64));
+        assert_eq!(PublicKeyParts::e_bytes(&public_key), [200].into());
+        assert_eq!(PublicKeyParts::n_bytes(&public_key), [101].into());
     }
 
     fn test_key_basics(private_key: &RsaPrivateKey) {

--- a/src/traits/keys.rs
+++ b/src/traits/keys.rs
@@ -1,5 +1,6 @@
 //! Traits related to the key components
 
+use alloc::boxed::Box;
 use crypto_bigint::{
     modular::{BoxedMontyForm, BoxedMontyParams},
     BoxedUint, NonZero,
@@ -26,6 +27,16 @@ pub trait PublicKeyParts {
     /// Returns precision (in bits) of `n`.
     fn n_bits_precision(&self) -> u32 {
         self.n().bits_precision()
+    }
+
+    /// Returns the big endian serialization of the modulus of the key
+    fn n_bytes(&self) -> Box<[u8]> {
+        self.n().to_be_bytes_trimmed_vartime()
+    }
+
+    /// Returns the big endian serialization of the public exponent of the key
+    fn e_bytes(&self) -> Box<[u8]> {
+        self.e().to_be_bytes_trimmed_vartime()
     }
 }
 


### PR DESCRIPTION
When serializing the exponent or the modulus from a key, `BoxedUint::to_be_bytes` will return a slice padded with zeroes on the left because of its inner representation. Not every implementation out there will handle leading zeroes.

This provides a `PublicKeyParts::n_bytes`/`e_bytes` that will strip out those leading zeros.

See https://github.com/RustCrypto/RSA/issues/518 for more context.

Depends:
  - https://github.com/RustCrypto/crypto-bigint/pull/824

Fixes #518 