### PR TITLE
chore(deps): use rc dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,8 +4,9 @@ version = 4
 
 [[package]]
 name = "aead"
-version = "0.6.0-rc.0"
-source = "git+https://github.com/RustCrypto/traits.git#915474f1ed5be0a19fd102d5f75ef8e04c765416"
+version = "0.6.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c01559752fbde7734af628961723aa734aa46351cbf5c9ce41133ad2ae1a09b9"
 dependencies = [
  "crypto-common",
  "inout",
@@ -13,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.0-pre.3"
+version = "0.9.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38e4da00d9978020ddaa556c1747cfcafc3f375cfadb109acfe8b752cfc373bf"
+checksum = "cd4838e4ad37bb032dea137f441d5f71c16c26c068af512e64c5bc13a88cdfc7"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -24,8 +25,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.11.0-pre.2"
-source = "git+https://github.com/RustCrypto/AEADs.git#976052da8e274544f0cd6b292f38a0d0a2934849"
+version = "0.11.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2be322be4a73a3a55ad74b9833238e76bfd6034ce69a05c1b41c879f6a3bdca6"
 dependencies = [
  "aead",
  "aes",
@@ -94,8 +96,9 @@ dependencies = [
 
 [[package]]
 name = "cbc"
-version = "0.2.0-pre.2"
-source = "git+https://github.com/RustCrypto/block-modes.git#3ec1c8191dea30def40c033513bbc8bdb3a9cd78"
+version = "0.2.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef95f543a56c245d9d0826ccbb34636ee983b3e846eff57bc5fc72e1bce1701"
 dependencies = [
  "cipher",
 ]
@@ -108,9 +111,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cipher"
-version = "0.5.0-pre.8"
+version = "0.5.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276974d2acb7cf592603150941fc1ff6442acdeb1dc653ac2825928f4703c131"
+checksum = "bd4ef774202f1749465fc7cf88d70fc30620e8cacd5429268f4bff7d003bd976"
 dependencies = [
  "crypto-common",
  "inout",
@@ -133,8 +136,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-pre.3"
-source = "git+https://github.com/RustCrypto/crypto-bigint.git#e08a2d04081bb0ba6f3b72ef45f0c7f619a5a826"
+version = "0.7.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edaae5fb9dac79a07260e0b2006799ff4f1d342ab243fd7d0892215113b27904"
 dependencies = [
  "num-traits",
  "rand_core 0.9.3",
@@ -145,16 +149,18 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/RustCrypto/traits.git#915474f1ed5be0a19fd102d5f75ef8e04c765416"
+version = "0.2.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a23fa214dea9efd4dacee5a5614646b30216ae0f05d4bb51bafb50e9da1c5be"
 dependencies = [
  "hybrid-array",
 ]
 
 [[package]]
 name = "crypto-primes"
-version = "0.7.0-dev"
-source = "git+https://github.com/entropyxyz/crypto-primes.git#04f927401b9eed948d4d26d149064cc292fea72e"
+version = "0.7.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae744b9f528151f8c440cf67498f24d2d1ac0ab536b5ce7b1f87a7a5961bd1c1"
 dependencies = [
  "crypto-bigint",
  "libm",
@@ -163,16 +169,18 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/RustCrypto/block-modes.git#3ec1c8191dea30def40c033513bbc8bdb3a9cd78"
+version = "0.10.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f239edce204df0e4503cccef3492552773d1ca4e002659a59ca715f099b45ca1"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "der"
-version = "0.8.0-rc.2"
-source = "git+https://github.com/RustCrypto/formats.git#f618cff13a91e1725479cfc6be64630c4c10a494"
+version = "0.8.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00a9651bf9c00a38b7c383073cb22fb42f20a5f978c9f97ad5c7128cbd3c1bd"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -181,8 +189,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-pre.10"
-source = "git+https://github.com/RustCrypto/traits.git#915474f1ed5be0a19fd102d5f75ef8e04c765416"
+version = "0.11.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460dd7f37e4950526b54a5a6b1f41b6c8e763c58eb9a8fc8fc05ba5c2f44ca7b"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -237,11 +246,10 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.6.0-rc.0"
+version = "0.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b92860fda25ab571512af210134cde2c42732cd53253bcee3f21b288b7afbc4"
+checksum = "7df2ef47489983b86b012ce4955b61fcfb1a99a761a1a8c79c3129e722da6795"
 dependencies = [
- "opaque-debug",
  "polyval",
 ]
 
@@ -262,8 +270,9 @@ checksum = "bcaaec4551594c969335c98c903c1397853d4198408ea609190f420500f6be71"
 
 [[package]]
 name = "hmac"
-version = "0.13.0-pre.5"
-source = "git+https://github.com/RustCrypto/MACs.git#64d671d5c375838173d18e30bc14dffc80c13e51"
+version = "0.13.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc6a2fcc35ab09136c6df2cdf9ca49790701420a3a6b5db0987dddbabc79b21"
 dependencies = [
  "digest",
 ]
@@ -348,15 +357,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
 name = "pbkdf2"
-version = "0.13.0-pre.1"
-source = "git+https://github.com/RustCrypto/password-hashes.git#aaf653989744a0c791d0d932bd6eb7fca8c154a6"
+version = "0.13.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2efb182a4d7d26aa7442a4ef2f91c5021c6abb61f9fdd251fcc2e327f5faaf6"
 dependencies = [
  "digest",
  "hmac",
@@ -364,17 +368,18 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dfbfa5c6f0906884269722c5478e72fd4d6c0e24fe600332c6d62359567ce1"
+checksum = "a8e58fab693c712c0d4e88f8eb3087b6521d060bcaf76aeb20cb192d809115ba"
 dependencies = [
  "base64ct",
 ]
 
 [[package]]
 name = "pkcs1"
-version = "0.8.0-rc.1"
-source = "git+https://github.com/RustCrypto/formats.git#f618cff13a91e1725479cfc6be64630c4c10a494"
+version = "0.8.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24e16d93c725fa250577ffdec06ebbff4cae3625b0e2881ac43a5427797ee8d3"
 dependencies = [
  "der",
  "pkcs8",
@@ -383,8 +388,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs5"
-version = "0.8.0-rc.3"
-source = "git+https://github.com/RustCrypto/formats.git#f618cff13a91e1725479cfc6be64630c4c10a494"
+version = "0.8.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce55cd4fe8b9065c54ec2c3eee57f84f899210227d0801e6130c80d3d5c5ae8"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -399,8 +405,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.3"
-source = "git+https://github.com/RustCrypto/formats.git#f618cff13a91e1725479cfc6be64630c4c10a494"
+version = "0.11.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f1843d4345dfe1a55e487db747a04c01af50415b03e937410e0a41d8cc24ec7"
 dependencies = [
  "der",
  "pkcs5",
@@ -410,13 +417,12 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.7.0-rc.0"
+version = "0.7.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01cbf5c028f9f862c6f7f5a5544307d7858634df190488d432ec470c8fbc063"
+checksum = "ff52e661730d7c6f95a72137e812e337eb5ff371d38d8588798e0df8404e610c"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "opaque-debug",
  "universal-hash",
 ]
 
@@ -626,8 +632,9 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "salsa20"
-version = "0.11.0-pre.2"
-source = "git+https://github.com/RustCrypto/stream-ciphers.git#18dfe15d6d2c597185acaeb136a562b9c2edf818"
+version = "0.11.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a9ebec7e5784021e346c32d27b6d3df9b034e2603f1d60ed84b9e1f701d9b9"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -635,8 +642,9 @@ dependencies = [
 
 [[package]]
 name = "scrypt"
-version = "0.12.0-pre.2"
-source = "git+https://github.com/RustCrypto/password-hashes.git#aaf653989744a0c791d0d932bd6eb7fca8c154a6"
+version = "0.12.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d88fc3052d284ebbd0fb26de47d04232da7cb2468c62afd7fc3f95e53dc0c1e"
 dependencies = [
  "pbkdf2",
  "salsa20",
@@ -696,8 +704,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-pre.5"
-source = "git+https://github.com/RustCrypto/hashes.git#7d44caf065dbeb3f10a372a26a8b9f1c927f8433"
+version = "0.11.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f9318facddf9ac32a33527066936837e189b3f23ced6edc1603720ead5e2b3d"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -706,8 +715,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-pre.5"
-source = "git+https://github.com/RustCrypto/hashes.git#7d44caf065dbeb3f10a372a26a8b9f1c927f8433"
+version = "0.11.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa1d2e6b3cc4e43a8258a9a3b17aa5dfd2cc5186c7024bba8a64aa65b2c71a59"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -716,8 +726,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0-pre.5"
-source = "git+https://github.com/RustCrypto/hashes.git#7d44caf065dbeb3f10a372a26a8b9f1c927f8433"
+version = "0.11.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e6a92fd180fd205defdc0b78288ce847c7309d329fd6647a814567e67db50e"
 dependencies = [
  "digest",
  "keccak",
@@ -725,8 +736,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#915474f1ed5be0a19fd102d5f75ef8e04c765416"
+version = "3.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ae074ff622614874804868b07d9cb786223082c9fe726a6653608f32f37b02"
 dependencies = [
  "digest",
  "rand_core 0.9.3",
@@ -734,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ac66481418fd7afdc584adcf3be9aa572cf6c2858814494dc2a01755f050bc"
+checksum = "c2f0e2bdca9b00f5be6dd3bb6647d50fd0f24a508a95f78e3bb2fe98d0403c85"
 dependencies = [
  "base64ct",
  "der",
@@ -792,9 +804,9 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "universal-hash"
-version = "0.6.0-rc.0"
+version = "0.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3517d72c5ca6d60f9f2e85d2c772e2652830062a685105a528d19dd823cf87d5"
+checksum = "17866ce72039aaa929b785c51d08d0395e02cb5eaffd3efdf634b9b1f80b8157"
 dependencies = [
  "crypto-common",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,19 +16,19 @@ rust-version = "1.83"
 rand_core = { version = "0.9.0", default-features = false }
 const-oid = { version = "0.10.0", default-features = false }
 subtle = { version = "2.6.1", default-features = false }
-digest = { version = "=0.11.0-pre.10", default-features = false, features = ["alloc", "oid"] }
-pkcs1 = { version = "0.8.0-rc.1", default-features = false, features = ["alloc", "pkcs8"] }
-pkcs8 = { version = "0.11.0-rc.3", default-features = false, features = ["alloc"] }
-signature = { version = "=3.0.0-pre", default-features = false, features = ["alloc", "digest", "rand_core"] }
-spki = { version = "0.8.0-rc.1", default-features = false, features = ["alloc"] }
+digest = { version = "0.11.0-rc.0", default-features = false, features = ["alloc", "oid"] }
+pkcs1 = { version = "0.8.0-rc.2", default-features = false, features = ["alloc", "pkcs8"] }
+pkcs8 = { version = "0.11.0-rc.4", default-features = false, features = ["alloc"] }
+signature = { version = "3.0.0-rc.0", default-features = false, features = ["alloc", "digest", "rand_core"] }
+spki = { version = "0.8.0-rc.2", default-features = false, features = ["alloc"] }
 zeroize = { version = "1.5", features = ["alloc"] }
-crypto-bigint = { version = "0.7.0-pre.3", default-features = false, features = ["zeroize", "alloc"] }
-crypto-primes = { version = "0.7.0-dev", default-features = false }
+crypto-bigint = { version = "0.7.0-pre.4", default-features = false, features = ["zeroize", "alloc"] }
+crypto-primes = { version = "0.7.0-pre.1", default-features = false }
 
 # optional dependencies
-sha1 = { version = "=0.11.0-pre.5", optional = true, default-features = false, features = ["oid"] }
+sha1 = { version = "0.11.0-rc.0", optional = true, default-features = false, features = ["oid"] }
 serdect = { version = "0.3.0", optional = true }
-sha2 = { version = "=0.11.0-pre.5", optional = true, default-features = false, features = ["oid"] }
+sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false, features = ["oid"] }
 serde = { version = "1.0.184", optional = true, default-features = false, features = ["derive"] }
 
 [dev-dependencies]
@@ -40,9 +40,9 @@ rand_xorshift = "0.4"
 rand_chacha = "0.9"
 rand = "0.9"
 rand_core = { version = "0.9.1", default-features = false }
-sha1 = { version = "=0.11.0-pre.5", default-features = false, features = ["oid"] }
-sha2 = { version = "=0.11.0-pre.5", default-features = false, features = ["oid"] }
-sha3 = { version = "=0.11.0-pre.5", default-features = false, features = ["oid"] }
+sha1 = { version = "0.11.0-rc.0", default-features = false, features = ["oid"] }
+sha2 = { version = "0.11.0-rc.0", default-features = false, features = ["oid"] }
+sha3 = { version = "0.11.0-rc.0", default-features = false, features = ["oid"] }
 hex = { version = "0.4.3", features = ["serde"] }
 serde_json = "1.0.138"
 serde = { version = "1.0.184", features = ["derive"] }
@@ -69,38 +69,3 @@ opt-level = 2
 
 [profile.bench]
 debug = true
-
-[patch.crates-io]
-# https://github.com/entropyxyz/crypto-primes/pull/74
-crypto-primes = { git = "https://github.com/entropyxyz/crypto-primes.git" }
-
-aead          = { git = "https://github.com/RustCrypto/traits.git" }
-crypto-common = { git = "https://github.com/RustCrypto/traits.git" }
-digest        = { git = "https://github.com/RustCrypto/traits.git" }
-signature     = { git = "https://github.com/RustCrypto/traits.git" }
-
-der   = { git = "https://github.com/RustCrypto/formats.git" }
-pkcs1 = { git = "https://github.com/RustCrypto/formats.git" }
-# https://github.com/RustCrypto/formats/pull/1844
-pkcs5 = { git = "https://github.com/RustCrypto/formats.git" }
-pkcs8 = { git = "https://github.com/RustCrypto/formats.git" }
-
-sha1   = { git = "https://github.com/RustCrypto/hashes.git" }
-sha2   = { git = "https://github.com/RustCrypto/hashes.git" }
-sha3   = { git = "https://github.com/RustCrypto/hashes.git" }
-
-# https://github.com/RustCrypto/password-hashes/pull/577
-# https://github.com/RustCrypto/password-hashes/pull/578
-# https://github.com/RustCrypto/password-hashes/pull/592
-pbkdf2 = { git = "https://github.com/RustCrypto/password-hashes.git" }
-scrypt = { git = "https://github.com/RustCrypto/password-hashes.git" }
-
-hmac = { git = "https://github.com/RustCrypto/MACs.git" }
-
-# https://github.com/RustCrypto/crypto-bigint/pull/824
-crypto-bigint = { git = "https://github.com/RustCrypto/crypto-bigint.git" }
-
-cbc = { git = "https://github.com/RustCrypto/block-modes.git" }
-ctr = { git = "https://github.com/RustCrypto/block-modes.git" }
-aes-gcm = { git = "https://github.com/RustCrypto/AEADs.git" }
-salsa20 = { git = "https://github.com/RustCrypto/stream-ciphers.git" }


### PR DESCRIPTION
 - `sha1` 0.11.0-rc.0
 - `sha2` 0.11.0-rc.0
 - `sha3` 0.11.0-rc.0
 - `digest` 0.11.0-rc.0
 - `signature` 0.3.0-rc.0
 - `pkcs1` 0.8.0-rc.2
 - `pkcs8` 0.11.0-rc.4
 - `spki` 0.8.0-rc.2