### PR TITLE
Remove deprecated `pkcs1v15` methods

### DIFF
--- a/src/pkcs1v15.rs
+++ b/src/pkcs1v15.rs
@@ -89,14 +89,6 @@ impl Pkcs1v15Sign {
             prefix: Box::new([]),
         }
     }
-
-    /// Create new PKCS#1 v1.5 padding for computing an unprefixed signature.
-    ///
-    /// This sets `hash_len` to `None` and uses an empty `prefix`.
-    #[deprecated(since = "0.9.0", note = "use Pkcs1v15Sign::new_unprefixed instead")]
-    pub fn new_raw() -> Self {
-        Self::new_unprefixed()
-    }
 }
 
 impl SignatureScheme for Pkcs1v15Sign {

--- a/src/pkcs1v15/signing_key.rs
+++ b/src/pkcs1v15/signing_key.rs
@@ -56,18 +56,6 @@ where
             phantom: Default::default(),
         })
     }
-
-    /// Create a new signing key with a prefix for the digest `D`.
-    #[deprecated(since = "0.9.0", note = "use SigningKey::new instead")]
-    pub fn new_with_prefix(key: RsaPrivateKey) -> Self {
-        Self::new(key)
-    }
-
-    /// Generate a new signing key with a prefix for the digest `D`.
-    #[deprecated(since = "0.9.0", note = "use SigningKey::random instead")]
-    pub fn random_with_prefix<R: CryptoRng + ?Sized>(rng: &mut R, bit_size: usize) -> Result<Self> {
-        Self::random(rng, bit_size)
-    }
 }
 
 impl<D> SigningKey<D>

--- a/src/pkcs1v15/verifying_key.rs
+++ b/src/pkcs1v15/verifying_key.rs
@@ -45,12 +45,6 @@ where
             phantom: Default::default(),
         }
     }
-
-    /// Create a new verifying key with a prefix for the digest `D`.
-    #[deprecated(since = "0.9.0", note = "use VerifyingKey::new instead")]
-    pub fn new_with_prefix(key: RsaPublicKey) -> Self {
-        Self::new(key)
-    }
 }
 
 impl<D> VerifyingKey<D>


### PR DESCRIPTION
In `rsa` v0.9 we changed these types to be prefixed-by-default, but retained and deprecated the `*_with_prefix` method names.

Now that `master` is tracking the v0.10 release, we can remove these.