### PR TITLE
Fix modulus size check in `check_public_with_max_size`

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -622,7 +622,7 @@ pub fn check_public(public_key: &impl PublicKeyParts) -> Result<()> {
 /// Check that the public key is well formed and has an exponent within acceptable bounds.
 #[inline]
 fn check_public_with_max_size(n: &BoxedUint, e: &BoxedUint, max_size: usize) -> Result<()> {
-    if n.bits() as usize > max_size {
+    if n.bits_vartime() as usize > max_size {
         return Err(Error::ModulusTooLarge);
     }
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -622,7 +622,7 @@ pub fn check_public(public_key: &impl PublicKeyParts) -> Result<()> {
 /// Check that the public key is well formed and has an exponent within acceptable bounds.
 #[inline]
 fn check_public_with_max_size(n: &BoxedUint, e: &BoxedUint, max_size: usize) -> Result<()> {
-    if n.bits_precision() as usize > max_size {
+    if n.bits() as usize > max_size {
         return Err(Error::ModulusTooLarge);
     }
 


### PR DESCRIPTION
It was checking the bits of precision, rather than the actual bit length of the key.

Closes #528.