### PR TITLE
Bump `crypto-bigint` to v0.7.0-pre.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-pre.4"
+version = "0.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edaae5fb9dac79a07260e0b2006799ff4f1d342ab243fd7d0892215113b27904"
+checksum = "a06a5e703b883b3744ddac8b7c5eade2d800d6559ef99760566f8103e3ad39bf"
 dependencies = [
  "num-traits",
  "rand_core 0.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ pkcs8 = { version = "0.11.0-rc.4", default-features = false, features = ["alloc"
 signature = { version = "3.0.0-rc.1", default-features = false, features = ["alloc", "digest", "rand_core"] }
 spki = { version = "0.8.0-rc.2", default-features = false, features = ["alloc"] }
 zeroize = { version = "1.5", features = ["alloc"] }
-crypto-bigint = { version = "0.7.0-pre.4", default-features = false, features = ["zeroize", "alloc"] }
+crypto-bigint = { version = "0.7.0-pre.5", default-features = false, features = ["zeroize", "alloc"] }
 crypto-primes = { version = "0.7.0-pre.1", default-features = false }
 
 # optional dependencies

--- a/src/pkcs1v15.rs
+++ b/src/pkcs1v15.rs
@@ -118,7 +118,7 @@ impl SignatureScheme for Pkcs1v15Sign {
             pub_key,
             self.prefix.as_ref(),
             hashed,
-            &BoxedUint::from_be_slice(sig, sig.len() as u32 * 8)?,
+            &BoxedUint::from_be_slice_vartime(sig),
         )
     }
 }

--- a/src/pkcs1v15/signature.rs
+++ b/src/pkcs1v15/signature.rs
@@ -1,9 +1,9 @@
 //! `RSASSA-PKCS1-v1_5` signatures.
 
-use ::signature::SignatureEncoding;
 use alloc::boxed::Box;
 use core::fmt::{Debug, Display, Formatter, LowerHex, UpperHex};
 use crypto_bigint::BoxedUint;
+use signature::SignatureEncoding;
 
 #[cfg(feature = "serde")]
 use serdect::serde::{de, Deserialize, Serialize};
@@ -34,14 +34,8 @@ impl TryFrom<&[u8]> for Signature {
     type Error = signature::Error;
 
     fn try_from(bytes: &[u8]) -> signature::Result<Self> {
-        let len = bytes.len();
-        let inner = BoxedUint::from_be_slice(bytes, len as u32 * 8);
-        #[cfg(feature = "std")]
-        let inner = inner
-            .map_err(|e| Box::new(e) as Box<dyn core::error::Error + Send + Sync + 'static>)?;
-        #[cfg(not(feature = "std"))]
-        let inner = inner.map_err(|_| signature::Error::new())?;
-
+        // TODO(tarcieri): max length restriction? (#350)
+        let inner = BoxedUint::from_be_slice_vartime(bytes);
         Ok(Self { inner })
     }
 }

--- a/src/pss.rs
+++ b/src/pss.rs
@@ -106,7 +106,7 @@ impl SignatureScheme for Pss {
         verify(
             pub_key,
             hashed,
-            &BoxedUint::from_be_slice(sig, sig.len() as u32 * 8)?,
+            &BoxedUint::from_be_slice_vartime(sig),
             sig.len(),
             &mut *self.digest,
             self.salt_len,

--- a/src/pss/signature.rs
+++ b/src/pss/signature.rs
@@ -1,9 +1,9 @@
 //! `RSASSA-PSS` signatures.
 
-use ::signature::SignatureEncoding;
 use alloc::boxed::Box;
 use core::fmt::{Debug, Display, Formatter, LowerHex, UpperHex};
 use crypto_bigint::BoxedUint;
+use signature::SignatureEncoding;
 
 #[cfg(feature = "serde")]
 use serdect::serde::{de, Deserialize, Serialize};
@@ -34,15 +34,8 @@ impl TryFrom<&[u8]> for Signature {
     type Error = signature::Error;
 
     fn try_from(bytes: &[u8]) -> signature::Result<Self> {
-        let len = bytes.len();
-        let inner = BoxedUint::from_be_slice(bytes, len as u32 * 8);
-
-        #[cfg(feature = "std")]
-        let inner = inner
-            .map_err(|e| Box::new(e) as Box<dyn core::error::Error + Send + Sync + 'static>)?;
-        #[cfg(not(feature = "std"))]
-        let inner = inner.map_err(|_| signature::Error::new())?;
-
+        // TODO(tarcieri): max length restriction? (#350)
+        let inner = BoxedUint::from_be_slice_vartime(bytes);
         Ok(Self { inner })
     }
 }


### PR DESCRIPTION
This notably adds `BoxedUint::from_be_slice_vartime` ~~which could be used for various public parameters, however this PR just bumps the version~~ which has been used where appropriate, namely for parsing signatures