### PR TITLE
Gate PKCS#1/PKCS#8 support on `encoding` feature

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -44,4 +44,4 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - env:
           RUSTDOCFLAGS: "-Dwarnings --cfg docsrs"
-        run: cargo doc --no-deps --features std,pem,serde,hazmat,sha2
+        run: cargo doc --no-deps --features std,serde,hazmat,sha2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,21 +13,21 @@ readme = "README.md"
 rust-version = "1.85"
 
 [dependencies]
-rand_core = { version = "0.9.0", default-features = false }
 const-oid = { version = "0.10.0", default-features = false }
-subtle = { version = "2.6.1", default-features = false }
-digest = { version = "0.11.0-rc.0", default-features = false, features = ["alloc", "oid"] }
-pkcs1 = { version = "0.8.0-rc.2", default-features = false, features = ["alloc", "pkcs8"] }
-pkcs8 = { version = "0.11.0-rc.4", default-features = false, features = ["alloc"] }
-signature = { version = "3.0.0-rc.1", default-features = false, features = ["alloc", "digest", "rand_core"] }
-spki = { version = "0.8.0-rc.2", default-features = false, features = ["alloc"] }
-zeroize = { version = "1.5", features = ["alloc"] }
 crypto-bigint = { version = "0.7.0-pre.5", default-features = false, features = ["zeroize", "alloc"] }
 crypto-primes = { version = "0.7.0-pre.1", default-features = false }
+digest = { version = "0.11.0-rc.0", default-features = false, features = ["alloc", "oid"] }
+rand_core = { version = "0.9.0", default-features = false }
+signature = { version = "3.0.0-rc.1", default-features = false, features = ["alloc", "digest", "rand_core"] }
+subtle = { version = "2.6.1", default-features = false }
+zeroize = { version = "1.5", features = ["alloc"] }
 
 # optional dependencies
-sha1 = { version = "0.11.0-rc.0", optional = true, default-features = false, features = ["oid"] }
+pkcs1 = { version = "0.8.0-rc.2", optional = true, default-features = false, features = ["alloc", "pem", "pkcs8"] }
+pkcs8 = { version = "0.11.0-rc.4", optional = true, default-features = false, features = ["alloc", "pem"] }
 serdect = { version = "0.3.0", optional = true }
+sha1 = { version = "0.11.0-rc.0", optional = true, default-features = false, features = ["oid"] }
+spki = { version = "0.8.0-rc.2", optional = true, default-features = false, features = ["alloc"] }
 sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false, features = ["oid"] }
 serde = { version = "1.0.184", optional = true, default-features = false, features = ["derive"] }
 
@@ -51,14 +51,13 @@ serde = { version = "1.0.184", features = ["derive"] }
 name = "key"
 
 [features]
-default = ["std", "pem"]
+default = ["std", "encoding"]
+encoding = ["dep:pkcs1", "dep:pkcs8", "dep:spki"]
 hazmat = []
 os_rng = ["rand_core/os_rng", "crypto-bigint/rand_core"]
-serde = ["dep:serde", "dep:serdect", "crypto-bigint/serde"]
-pem = ["pkcs1/pem", "pkcs8/pem"]
+serde = ["encoding", "dep:serde", "dep:serdect", "crypto-bigint/serde"]
 pkcs5 = ["pkcs8/encryption"]
 std = ["pkcs1/std", "pkcs8/std", "rand_core/std", "crypto-bigint/rand"]
-
 
 [package.metadata.docs.rs]
 features = ["std", "pem", "serde", "hazmat", "sha2"]

--- a/src/algorithms/pkcs1v15.rs
+++ b/src/algorithms/pkcs1v15.rs
@@ -7,8 +7,8 @@
 //! [RFC8017 § 8.2]: https://datatracker.ietf.org/doc/html/rfc8017#section-8.2
 
 use alloc::vec::Vec;
+use const_oid::AssociatedOid;
 use digest::Digest;
-use pkcs8::AssociatedOid;
 use rand_core::TryCryptoRng;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 use zeroize::Zeroizing;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -50,9 +50,11 @@ pub enum Error {
     PublicExponentTooLarge,
 
     /// PKCS#1 error.
+    #[cfg(feature = "encoding")]
     Pkcs1(pkcs1::Error),
 
     /// PKCS#8 error.
+    #[cfg(feature = "encoding")]
     Pkcs8(pkcs8::Error),
 
     /// Internal error.
@@ -95,7 +97,9 @@ impl core::fmt::Display for Error {
             Error::ModulusTooLarge => write!(f, "modulus too large"),
             Error::PublicExponentTooSmall => write!(f, "public exponent too small"),
             Error::PublicExponentTooLarge => write!(f, "public exponent too large"),
+            #[cfg(feature = "encoding")]
             Error::Pkcs1(err) => write!(f, "{}", err),
+            #[cfg(feature = "encoding")]
             Error::Pkcs8(err) => write!(f, "{}", err),
             Error::Internal => write!(f, "internal error"),
             Error::LabelTooLong => write!(f, "label too long"),
@@ -107,12 +111,14 @@ impl core::fmt::Display for Error {
     }
 }
 
+#[cfg(feature = "encoding")]
 impl From<pkcs1::Error> for Error {
     fn from(err: pkcs1::Error) -> Error {
         Error::Pkcs1(err)
     }
 }
 
+#[cfg(feature = "encoding")]
 impl From<pkcs8::Error> for Error {
     fn from(err: pkcs8::Error) -> Error {
         Error::Pkcs8(err)

--- a/src/key.rs
+++ b/src/key.rs
@@ -703,8 +703,10 @@ mod tests {
     use crate::traits::{PrivateKeyParts, PublicKeyParts};
 
     use hex_literal::hex;
-    use pkcs8::DecodePrivateKey;
     use rand_chacha::{rand_core::SeedableRng, ChaCha8Rng};
+
+    #[cfg(feature = "encoding")]
+    use pkcs8::DecodePrivateKey;
 
     #[test]
     fn test_from_into() {
@@ -1014,6 +1016,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "encoding")]
     fn build_key_from_primes() {
         const RSA_2048_PRIV_DER: &[u8] = include_bytes!("../tests/examples/pkcs8/rsa2048-priv.der");
         let ref_key = RsaPrivateKey::from_pkcs8_der(RSA_2048_PRIV_DER).unwrap();
@@ -1035,6 +1038,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "encoding")]
     fn build_key_from_p_q() {
         const RSA_2048_SP800_PRIV_DER: &[u8] =
             include_bytes!("../tests/examples/pkcs8/rsa2048-sp800-56b-priv.der");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@
 //!
 //! ```
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! # #[cfg(all(feature = "pem", feature = "std"))]
+//! # #[cfg(all(feature = "encoding", feature = "std"))]
 //! # {
 //! use rsa::{RsaPublicKey, pkcs1::DecodeRsaPublicKey};
 //!
@@ -189,7 +189,7 @@
 //!
 //! ```
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! # #[cfg(all(feature = "pem", feature = "std"))]
+//! # #[cfg(all(feature = "encoding", feature = "std"))]
 //! # {
 //! use rsa::{RsaPublicKey, pkcs8::DecodePublicKey};
 //!
@@ -238,7 +238,9 @@ mod dummy_rng;
 mod encoding;
 mod key;
 
+#[cfg(feature = "encoding")]
 pub use pkcs1;
+#[cfg(feature = "encoding")]
 pub use pkcs8;
 #[cfg(feature = "sha2")]
 pub use sha2;

--- a/src/pkcs1v15.rs
+++ b/src/pkcs1v15.rs
@@ -18,10 +18,10 @@ pub use self::{
 };
 
 use alloc::{boxed::Box, vec::Vec};
+use const_oid::AssociatedOid;
 use core::fmt::Debug;
 use crypto_bigint::BoxedUint;
 use digest::Digest;
-use pkcs8::AssociatedOid;
 use rand_core::TryCryptoRng;
 
 use crate::algorithms::pad::{uint_to_be_pad, uint_to_zeroizing_be_pad};

--- a/src/pkcs1v15/signature.rs
+++ b/src/pkcs1v15/signature.rs
@@ -7,6 +7,7 @@ use signature::SignatureEncoding;
 
 #[cfg(feature = "serde")]
 use serdect::serde::{de, Deserialize, Serialize};
+#[cfg(feature = "encoding")]
 use spki::{
     der::{asn1::BitString, Result as DerResult},
     SignatureBitStringEncoding,
@@ -24,6 +25,7 @@ impl SignatureEncoding for Signature {
     type Repr = Box<[u8]>;
 }
 
+#[cfg(feature = "encoding")]
 impl SignatureBitStringEncoding for Signature {
     fn to_bitstring(&self) -> DerResult<BitString> {
         BitString::new(0, self.to_vec())

--- a/src/pkcs1v15/signing_key.rs
+++ b/src/pkcs1v15/signing_key.rs
@@ -1,27 +1,30 @@
-use super::{oid, pkcs1v15_generate_prefix, sign, Signature, VerifyingKey};
+use super::{pkcs1v15_generate_prefix, sign, Signature, VerifyingKey};
 use crate::{dummy_rng::DummyRng, Result, RsaPrivateKey};
 use alloc::vec::Vec;
+use const_oid::AssociatedOid;
 use core::marker::PhantomData;
 use digest::Digest;
-use pkcs8::{
-    spki::{
-        der::AnyRef, AlgorithmIdentifierRef, AssociatedAlgorithmIdentifier,
-        SignatureAlgorithmIdentifier,
-    },
-    AssociatedOid, EncodePrivateKey, SecretDocument,
-};
 use rand_core::{CryptoRng, TryCryptoRng};
-#[cfg(feature = "serde")]
-use {
-    pkcs8::DecodePrivateKey,
-    serdect::serde::{de, ser, Deserialize, Serialize},
-};
-
 use signature::{
     hazmat::PrehashSigner, DigestSigner, Keypair, MultipartSigner, RandomizedDigestSigner,
     RandomizedMultipartSigner, RandomizedSigner, Signer,
 };
 use zeroize::ZeroizeOnDrop;
+
+#[cfg(feature = "encoding")]
+use {
+    super::oid,
+    pkcs8::{EncodePrivateKey, SecretDocument},
+    spki::{
+        der::AnyRef, AlgorithmIdentifierRef, AssociatedAlgorithmIdentifier,
+        SignatureAlgorithmIdentifier,
+    },
+};
+#[cfg(feature = "serde")]
+use {
+    pkcs8::DecodePrivateKey,
+    serdect::serde::{de, ser, Deserialize, Serialize},
+};
 
 /// Signing key for `RSASSA-PKCS1-v1_5` signatures as described in [RFC8017 § 8.2].
 ///
@@ -192,6 +195,7 @@ where
     }
 }
 
+#[cfg(feature = "encoding")]
 impl<D> AssociatedAlgorithmIdentifier for SigningKey<D>
 where
     D: Digest,
@@ -201,6 +205,7 @@ where
     const ALGORITHM_IDENTIFIER: AlgorithmIdentifierRef<'static> = pkcs1::ALGORITHM_ID;
 }
 
+#[cfg(feature = "encoding")]
 impl<D> EncodePrivateKey for SigningKey<D>
 where
     D: Digest,
@@ -243,6 +248,7 @@ where
     }
 }
 
+#[cfg(feature = "encoding")]
 impl<D> SignatureAlgorithmIdentifier for SigningKey<D>
 where
     D: Digest + oid::RsaSignatureAssociatedOid,
@@ -256,6 +262,7 @@ where
         };
 }
 
+#[cfg(feature = "encoding")]
 impl<D> TryFrom<pkcs8::PrivateKeyInfoRef<'_>> for SigningKey<D>
 where
     D: Digest + AssociatedOid,

--- a/src/pss.rs
+++ b/src/pss.rs
@@ -23,20 +23,24 @@ use alloc::{boxed::Box, vec::Vec};
 use core::fmt::{self, Debug};
 use crypto_bigint::BoxedUint;
 
-use const_oid::AssociatedOid;
 use digest::{Digest, DynDigest, FixedOutputReset};
-use pkcs1::RsaPssParams;
-use pkcs8::spki::{der::Any, AlgorithmIdentifierOwned};
 use rand_core::TryCryptoRng;
 
 use crate::algorithms::pad::{uint_to_be_pad, uint_to_zeroizing_be_pad};
 use crate::algorithms::pss::*;
 use crate::algorithms::rsa::{rsa_decrypt_and_check, rsa_encrypt};
-use crate::encoding::ID_RSASSA_PSS;
 use crate::errors::{Error, Result};
 use crate::traits::PublicKeyParts;
 use crate::traits::SignatureScheme;
 use crate::{RsaPrivateKey, RsaPublicKey};
+
+#[cfg(feature = "encoding")]
+use {
+    crate::encoding::ID_RSASSA_PSS,
+    const_oid::AssociatedOid,
+    pkcs1::RsaPssParams,
+    spki::{der::Any, AlgorithmIdentifierOwned},
+};
 
 /// Digital signatures using PSS padding.
 pub struct Pss {
@@ -230,7 +234,8 @@ fn sign_pss_with_salt_digest<T: TryCryptoRng + ?Sized, D: Digest + FixedOutputRe
 }
 
 /// Returns the [`AlgorithmIdentifierOwned`] associated with PSS signature using a given digest.
-pub fn get_default_pss_signature_algo_id<D>() -> pkcs8::spki::Result<AlgorithmIdentifierOwned>
+#[cfg(feature = "encoding")]
+pub fn get_default_pss_signature_algo_id<D>() -> spki::Result<AlgorithmIdentifierOwned>
 where
     D: Digest + AssociatedOid,
 {
@@ -238,7 +243,8 @@ where
     get_pss_signature_algo_id::<D>(salt_len)
 }
 
-fn get_pss_signature_algo_id<D>(salt_len: u8) -> pkcs8::spki::Result<AlgorithmIdentifierOwned>
+#[cfg(feature = "encoding")]
+fn get_pss_signature_algo_id<D>(salt_len: u8) -> spki::Result<AlgorithmIdentifierOwned>
 where
     D: Digest + AssociatedOid,
 {
@@ -250,7 +256,7 @@ where
     })
 }
 
-#[cfg(all(test, feature = "pem"))]
+#[cfg(all(test, feature = "encoding"))]
 mod test {
     use crate::pss::{BlindedSigningKey, Pss, Signature, SigningKey, VerifyingKey};
     use crate::{RsaPrivateKey, RsaPublicKey};

--- a/src/pss/signature.rs
+++ b/src/pss/signature.rs
@@ -7,6 +7,7 @@ use signature::SignatureEncoding;
 
 #[cfg(feature = "serde")]
 use serdect::serde::{de, Deserialize, Serialize};
+#[cfg(feature = "encoding")]
 use spki::{
     der::{asn1::BitString, Result as DerResult},
     SignatureBitStringEncoding,
@@ -24,6 +25,7 @@ impl SignatureEncoding for Signature {
     type Repr = Box<[u8]>;
 }
 
+#[cfg(feature = "encoding")]
 impl SignatureBitStringEncoding for Signature {
     fn to_bitstring(&self) -> DerResult<BitString> {
         BitString::new(0, self.to_vec())

--- a/src/pss/verifying_key.rs
+++ b/src/pss/verifying_key.rs
@@ -1,13 +1,16 @@
 use super::{verify_digest, Signature};
-use crate::encoding::ID_RSASSA_PSS;
 use crate::RsaPublicKey;
 use core::marker::PhantomData;
 use digest::{Digest, FixedOutputReset};
-use pkcs8::{
-    spki::{der::AnyRef, AlgorithmIdentifierRef, AssociatedAlgorithmIdentifier},
-    AssociatedOid, Document, EncodePublicKey,
-};
 use signature::{hazmat::PrehashVerifier, DigestVerifier, Verifier};
+
+#[cfg(feature = "encoding")]
+use {
+    crate::encoding::ID_RSASSA_PSS,
+    const_oid::AssociatedOid,
+    pkcs8::{Document, EncodePublicKey},
+    spki::{der::AnyRef, AlgorithmIdentifierRef, AssociatedAlgorithmIdentifier},
+};
 #[cfg(feature = "serde")]
 use {
     serdect::serde::{de, ser, Deserialize, Serialize},
@@ -110,6 +113,7 @@ where
     }
 }
 
+#[cfg(feature = "encoding")]
 impl<D> AssociatedAlgorithmIdentifier for VerifyingKey<D>
 where
     D: Digest,
@@ -133,11 +137,12 @@ where
     }
 }
 
+#[cfg(feature = "encoding")]
 impl<D> EncodePublicKey for VerifyingKey<D>
 where
     D: Digest,
 {
-    fn to_public_key_der(&self) -> pkcs8::spki::Result<Document> {
+    fn to_public_key_der(&self) -> spki::Result<Document> {
         self.inner.to_public_key_der()
     }
 }
@@ -160,13 +165,14 @@ where
     }
 }
 
+#[cfg(feature = "encoding")]
 impl<D> TryFrom<pkcs8::SubjectPublicKeyInfoRef<'_>> for VerifyingKey<D>
 where
     D: Digest + AssociatedOid,
 {
-    type Error = pkcs8::spki::Error;
+    type Error = spki::Error;
 
-    fn try_from(spki: pkcs8::SubjectPublicKeyInfoRef<'_>) -> pkcs8::spki::Result<Self> {
+    fn try_from(spki: pkcs8::SubjectPublicKeyInfoRef<'_>) -> spki::Result<Self> {
         match spki.algorithm.oid {
             ID_RSASSA_PSS | pkcs1::ALGORITHM_OID => (),
             _ => {

--- a/tests/pkcs1.rs
+++ b/tests/pkcs1.rs
@@ -1,5 +1,7 @@
 //! PKCS#1 encoding tests
 
+#![cfg(feature = "encoding")]
+
 use crypto_bigint::BoxedUint;
 use hex_literal::hex;
 use rsa::{
@@ -9,7 +11,7 @@ use rsa::{
 };
 use subtle::ConstantTimeEq;
 
-#[cfg(feature = "pem")]
+#[cfg(feature = "encoding")]
 use rsa::pkcs1::LineEnding;
 
 /// RSA-2048 PKCS#1 private key encoded as ASN.1 DER.
@@ -31,19 +33,19 @@ const RSA_2048_PUB_DER: &[u8] = include_bytes!("examples/pkcs1/rsa2048-pub.der")
 const RSA_4096_PUB_DER: &[u8] = include_bytes!("examples/pkcs1/rsa4096-pub.der");
 
 /// RSA-2048 PKCS#1 private key encoded as PEM
-#[cfg(feature = "pem")]
+#[cfg(feature = "encoding")]
 const RSA_2048_PRIV_PEM: &str = include_str!("examples/pkcs1/rsa2048-priv.pem");
 
 /// RSA-4096 PKCS#1 private key encoded as PEM
-#[cfg(feature = "pem")]
+#[cfg(feature = "encoding")]
 const RSA_4096_PRIV_PEM: &str = include_str!("examples/pkcs1/rsa4096-priv.pem");
 
 /// RSA-2048 PKCS#1 public key encoded as PEM
-#[cfg(feature = "pem")]
+#[cfg(feature = "encoding")]
 const RSA_2048_PUB_PEM: &str = include_str!("examples/pkcs1/rsa2048-pub.pem");
 
 /// RSA-4096 PKCS#1 public key encoded as PEM
-#[cfg(feature = "pem")]
+#[cfg(feature = "encoding")]
 const RSA_4096_PUB_PEM: &str = include_str!("examples/pkcs1/rsa4096-pub.pem");
 
 #[test]
@@ -272,7 +274,7 @@ fn encode_rsa4096_pub_der() {
 }
 
 #[test]
-#[cfg(feature = "pem")]
+#[cfg(feature = "encoding")]
 fn decode_rsa2048_priv_pem() {
     let key = RsaPrivateKey::from_pkcs1_pem(RSA_2048_PRIV_PEM).unwrap();
 
@@ -332,7 +334,7 @@ fn decode_rsa2048_priv_pem() {
 }
 
 #[test]
-#[cfg(feature = "pem")]
+#[cfg(feature = "encoding")]
 fn decode_rsa4096_priv_pem() {
     let key = RsaPrivateKey::from_pkcs1_pem(RSA_4096_PRIV_PEM).unwrap();
 
@@ -417,7 +419,7 @@ fn decode_rsa4096_priv_pem() {
 }
 
 #[test]
-#[cfg(feature = "pem")]
+#[cfg(feature = "encoding")]
 fn decode_rsa2048_pub_pem() {
     let key = RsaPublicKey::from_pkcs1_pem(RSA_2048_PUB_PEM).unwrap();
 
@@ -441,7 +443,7 @@ fn decode_rsa2048_pub_pem() {
 }
 
 #[test]
-#[cfg(feature = "pem")]
+#[cfg(feature = "encoding")]
 fn decode_rsa4096_pub_pem() {
     let key = RsaPublicKey::from_pkcs1_pem(RSA_4096_PUB_PEM).unwrap();
 
@@ -473,7 +475,7 @@ fn decode_rsa4096_pub_pem() {
 }
 
 #[test]
-#[cfg(feature = "pem")]
+#[cfg(feature = "encoding")]
 fn encode_rsa2048_priv_pem() {
     let key = RsaPrivateKey::from_pkcs1_pem(RSA_2048_PRIV_PEM).unwrap();
     let pem = key.to_pkcs1_pem(LineEnding::LF).unwrap();
@@ -481,7 +483,7 @@ fn encode_rsa2048_priv_pem() {
 }
 
 #[test]
-#[cfg(feature = "pem")]
+#[cfg(feature = "encoding")]
 fn encode_rsa4096_priv_pem() {
     let key = RsaPrivateKey::from_pkcs1_pem(RSA_4096_PRIV_PEM).unwrap();
     let pem = key.to_pkcs1_pem(LineEnding::LF).unwrap();
@@ -489,7 +491,7 @@ fn encode_rsa4096_priv_pem() {
 }
 
 #[test]
-#[cfg(feature = "pem")]
+#[cfg(feature = "encoding")]
 fn encode_rsa2048_pub_pem() {
     let key = RsaPublicKey::from_pkcs1_pem(RSA_2048_PUB_PEM).unwrap();
     let pem = key.to_pkcs1_pem(LineEnding::LF).unwrap();
@@ -497,7 +499,7 @@ fn encode_rsa2048_pub_pem() {
 }
 
 #[test]
-#[cfg(feature = "pem")]
+#[cfg(feature = "encoding")]
 fn encode_rsa4096_pub_pem() {
     let key = RsaPublicKey::from_pkcs1_pem(RSA_4096_PUB_PEM).unwrap();
     let pem = key.to_pkcs1_pem(LineEnding::LF).unwrap();

--- a/tests/pkcs1v15.rs
+++ b/tests/pkcs1v15.rs
@@ -1,5 +1,5 @@
 // simple but prevent regression - see https://github.com/RustCrypto/RSA/issues/329
-#[cfg(feature = "pem")]
+#[cfg(feature = "encoding")]
 #[test]
 fn signature_stringify() {
     use pkcs8::DecodePrivateKey;
@@ -22,7 +22,7 @@ fn signature_stringify() {
     assert_eq!(signature.to_string(), expected);
 }
 
-#[cfg(feature = "pem")]
+#[cfg(feature = "encoding")]
 #[test]
 fn signing_key_new_same_as_from() {
     use pkcs1::DecodeRsaPrivateKey;

--- a/tests/pkcs8.rs
+++ b/tests/pkcs8.rs
@@ -1,5 +1,7 @@
 //! PKCS#8 encoding tests
 
+#![cfg(feature = "encoding")]
+
 use crypto_bigint::BoxedUint;
 use hex_literal::hex;
 use rsa::{
@@ -12,7 +14,7 @@ use rsa::{
 use sha2::Sha256;
 use subtle::ConstantTimeEq;
 
-#[cfg(feature = "pem")]
+#[cfg(feature = "encoding")]
 use rsa::pkcs8::LineEnding;
 
 /// RSA-2048 PKCS#8 private key encoded as ASN.1 DER
@@ -22,11 +24,11 @@ const RSA_2048_PRIV_DER: &[u8] = include_bytes!("examples/pkcs8/rsa2048-priv.der
 const RSA_2048_PUB_DER: &[u8] = include_bytes!("examples/pkcs8/rsa2048-pub.der");
 
 /// RSA-2048 PKCS#8 private key encoded as PEM
-#[cfg(feature = "pem")]
+#[cfg(feature = "encoding")]
 const RSA_2048_PRIV_PEM: &str = include_str!("examples/pkcs8/rsa2048-priv.pem");
 
 /// RSA-2048 PKCS#8 public key encoded as PEM
-#[cfg(feature = "pem")]
+#[cfg(feature = "encoding")]
 const RSA_2048_PUB_PEM: &str = include_str!("examples/pkcs8/rsa2048-pub.pem");
 
 /// RSA-2048 PSS PKCS#8 private key encoded as DER
@@ -226,7 +228,7 @@ fn encode_rsa2048_pub_der() {
 }
 
 #[test]
-#[cfg(feature = "pem")]
+#[cfg(feature = "encoding")]
 fn decode_rsa2048_priv_pem() {
     let key = RsaPrivateKey::from_pkcs8_pem(RSA_2048_PRIV_PEM).unwrap();
 
@@ -287,7 +289,7 @@ fn decode_rsa2048_priv_pem() {
 }
 
 #[test]
-#[cfg(feature = "pem")]
+#[cfg(feature = "encoding")]
 fn decode_rsa2048_pub_pem() {
     let key = RsaPublicKey::from_public_key_pem(RSA_2048_PUB_PEM).unwrap();
 
@@ -312,7 +314,7 @@ fn decode_rsa2048_pub_pem() {
 }
 
 #[test]
-#[cfg(feature = "pem")]
+#[cfg(feature = "encoding")]
 fn encode_rsa2048_priv_pem() {
     let key = RsaPrivateKey::from_pkcs8_pem(RSA_2048_PRIV_PEM).unwrap();
     let pem = key.to_pkcs8_pem(LineEnding::LF).unwrap();
@@ -320,7 +322,7 @@ fn encode_rsa2048_priv_pem() {
 }
 
 #[test]
-#[cfg(feature = "pem")]
+#[cfg(feature = "encoding")]
 fn encode_rsa2048_pub_pem() {
     let key = RsaPublicKey::from_public_key_pem(RSA_2048_PUB_PEM).unwrap();
     let pem = key.to_public_key_pem(LineEnding::LF).unwrap();

--- a/tests/wycheproof.rs
+++ b/tests/wycheproof.rs
@@ -1,5 +1,7 @@
 //! Executes tests based on the wycheproof testsuite.
 
+#![cfg(feature = "encoding")]
+
 // This implementation here is based on
 // <https://github.com/ctz/graviola/blob/main/graviola/tests/wycheproof.rs>
 


### PR DESCRIPTION
Support for these formats has a number of dependencies required, and isn't always necessary, e.g. the `ssh-key` crate implements an entirely different encoding format for RSA keys.

Making support an optional feature avoids incurring these dependencies when that's the case.

This commit also removes the `pem` feature and makes PEM support on-by-default whenever `encoding` is enabled. This only adds the `pem-rfc7468` dependency. Most users will probably want PEM support if they have the `encoding` feature enabled.