### PR TITLE
PSS: Improve interoperability with optional auto salt length detection during verification

### DIFF
--- a/src/pss/blinded_signing_key.rs
+++ b/src/pss/blinded_signing_key.rs
@@ -219,7 +219,7 @@ where
     fn verifying_key(&self) -> Self::VerifyingKey {
         VerifyingKey {
             inner: self.inner.to_public_key(),
-            salt_len: self.salt_len,
+            salt_len: Some(self.salt_len),
             phantom: Default::default(),
         }
     }

--- a/src/pss/signing_key.rs
+++ b/src/pss/signing_key.rs
@@ -251,7 +251,7 @@ where
     fn verifying_key(&self) -> Self::VerifyingKey {
         VerifyingKey {
             inner: self.inner.to_public_key(),
-            salt_len: self.salt_len,
+            salt_len: Some(self.salt_len),
             phantom: Default::default(),
         }
     }

--- a/src/pss/verifying_key.rs
+++ b/src/pss/verifying_key.rs
@@ -27,7 +27,7 @@ where
     D: Digest,
 {
     pub(super) inner: RsaPublicKey,
-    pub(super) salt_len: usize,
+    pub(super) salt_len: Option<usize>,
     pub(super) phantom: PhantomData<D>,
 }
 
@@ -45,13 +45,23 @@ where
     pub fn new_with_salt_len(key: RsaPublicKey, salt_len: usize) -> Self {
         Self {
             inner: key,
-            salt_len,
+            salt_len: Some(salt_len),
+            phantom: Default::default(),
+        }
+    }
+
+    /// Create a new RSASSA-PSS verifying key.
+    /// Attempts to automatically detect the salt length.
+    pub fn new_with_auto_salt_len(key: RsaPublicKey) -> Self {
+        Self {
+            inner: key,
+            salt_len: None,
             phantom: Default::default(),
         }
     }
 
     /// Return specified salt length for this key
-    pub fn salt_len(&self) -> usize {
+    pub fn salt_len(&self) -> Option<usize> {
         self.salt_len
     }
 }


### PR DESCRIPTION

This PR adds an optional method to automatically detect the salt length during RSA-PSS signature verification.

Should Fix: #361 and similar situations.

### Problem
The crate currently requires a fixed salt length for PSS verification. This prevents verification of signatures where the salt length is not known beforehand, a situation not uncommon in interoperability contexts.

This capability was previously available but was removed in PR #294.

### Solution
This change re-introduces salt length auto-detection as an explicit, opt-in feature. A new constructor, `VerifyingKey::new_with_auto_salt_len`, creates a verifier that performs this detection during verification.

*   The change is opt-in and does not affect default behavior.
*   It improves interoperability by handling signatures with variable / unknown salt lengths.
*   The salt detection logic is implemented in constant(-ish) time to resist timing attacks.

### Commit Structure
This PR consists of three commits:

1.  **test:** Adds a failing unit test to demonstrate the issue.
2.  **feat:** Implements `new_with_auto_salt_len` and re-introduces the previous detection logic.
3.  **fix:** Updates the detection logic to be less prone to timing attacks.

Because salt length auto-detection is OpenSSL's default, it's likely that many systems were built without a mechanism to enforce or communicate a fixed salt length. Without this PR, it was impossible to reliably use this crate in my current project, and I suspect others face the same blocker. I've lost quite a bit of time dealing with seemingly random signature verification failures until I realized the crux of the problem.