### PR TITLE
Cargo.toml: fix docsrs feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ pkcs5 = ["pkcs8/encryption"]
 std = ["pkcs1?/std", "pkcs8?/std", "rand_core/std", "crypto-bigint/rand"]
 
 [package.metadata.docs.rs]
-features = ["std", "pem", "serde", "hazmat", "sha2"]
+features = ["std", "serde", "hazmat", "sha2"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [profile.dev]


### PR DESCRIPTION
https://docs.rs/crate/rsa/0.10.0-rc.4/builds/2384222

    [INFO] [stderr] error: the package 'rsa' does not contain this feature: pem