### PR TITLE
Remove patch.crates-io dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,16 +78,18 @@ checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0-rc.4"
-source = "git+https://github.com/RustCrypto/utils#adfccfea2686ef191b607f653cc3587753b6ec66"
+version = "0.11.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9ef36a6fcdb072aa548f3da057640ec10859eb4e91ddf526ee648d50c76a949"
 dependencies = [
  "hybrid-array",
 ]
 
 [[package]]
 name = "block-padding"
-version = "0.4.0-rc.3"
-source = "git+https://github.com/RustCrypto/utils#adfccfea2686ef191b607f653cc3587753b6ec66"
+version = "0.4.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e59c1aab3e6c5e56afe1b7e8650be9b5a791cb997bdea449194ae62e4bf8c73"
 dependencies = [
  "hybrid-array",
 ]
@@ -109,8 +111,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.0"
-source = "git+https://github.com/RustCrypto/traits#b91704f633a83798c1ba89f908cff067ddc7d843"
+version = "0.5.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e12a13eb01ded5d32ee9658d94f553a19e804204f2dc811df69ab4d9e0cb8c7"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -134,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.2"
+version = "0.7.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2e1b5372dde38eafb812e67711778f9f30dd45c3e449d58e618219e82c8188"
+checksum = "7c069823f41bdc75e99546bfd59eb1ed27d69dc720e5c949fe502b82926f8448"
 dependencies = [
  "num-traits",
  "rand_core",
@@ -147,8 +150,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.3"
-source = "git+https://github.com/RustCrypto/traits#b91704f633a83798c1ba89f908cff067ddc7d843"
+version = "0.2.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8235645834fbc6832939736ce2f2d08192652269e11010a6240f61b908a1c6"
 dependencies = [
  "hybrid-array",
 ]
@@ -166,8 +170,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.10.0-rc.0"
-source = "git+https://github.com/RustCrypto/block-modes#044d1010efc422c4ee76263f9b70102d77fd342b"
+version = "0.10.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27e41d01c6f73b9330177f5cf782ae5b581b5f2c7840e298e0275ceee5001434"
 dependencies = [
  "cipher",
 ]
@@ -185,8 +190,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.0"
-source = "git+https://github.com/RustCrypto/traits#b91704f633a83798c1ba89f908cff067ddc7d843"
+version = "0.11.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a4aae35a0fcbe22ff1be50fe96df72002d5a4a6fb4aae9193cf2da0daa36da2"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -272,8 +278,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.2.0-rc.5"
-source = "git+https://github.com/RustCrypto/utils#adfccfea2686ef191b607f653cc3587753b6ec66"
+version = "0.2.0-rc.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1603f76010ff924b616c8f44815a42eb10fb0b93d308b41deaa8da6d4251fd4b"
 dependencies = [
  "block-padding",
  "hybrid-array",
@@ -575,8 +582,9 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "salsa20"
-version = "0.11.0-rc.0"
-source = "git+https://github.com/RustCrypto/stream-ciphers#1b7c8220310edf3614e06e4abd1ab476c3024445"
+version = "0.11.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3ff3b81c8a6e381bc1673768141383f9328048a60edddcfc752a8291a138443"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -656,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f9318facddf9ac32a33527066936837e189b3f23ced6edc1603720ead5e2b3d"
+checksum = "c5e046edf639aa2e7afb285589e5405de2ef7e61d4b0ac1e30256e3eab911af9"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -667,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa1d2e6b3cc4e43a8258a9a3b17aa5dfd2cc5186c7024bba8a64aa65b2c71a59"
+checksum = "d1e3878ab0f98e35b2df35fe53201d088299b41a6bb63e3e34dada2ac4abd924"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -678,9 +686,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e6a92fd180fd205defdc0b78288ce847c7309d329fd6647a814567e67db50e"
+checksum = "b3c185ed8cff82204014bfaa7649b4c945ca565e03c0534eb33a8d2a01572932"
 dependencies = [
  "digest",
  "keccak",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ rust-version = "1.85"
 
 [dependencies]
 const-oid = { version = "0.10", default-features = false }
-crypto-bigint = { version = "0.7.0-rc.2", default-features = false, features = ["zeroize", "alloc"] }
+crypto-bigint = { version = "0.7.0-rc.4", default-features = false, features = ["zeroize", "alloc"] }
 crypto-primes = { version = "0.7.0-pre.1", default-features = false }
-digest = { version = "0.11.0-rc.0", default-features = false, features = ["alloc", "oid"] }
+digest = { version = "0.11.0-rc.1", default-features = false, features = ["alloc", "oid"] }
 rand_core = { version = "0.9", default-features = false }
 signature = { version = "3.0.0-rc.2", default-features = false, features = ["alloc", "digest", "rand_core"] }
 subtle = { version = "2.6.1", default-features = false }
@@ -26,9 +26,9 @@ zeroize = { version = "1.5", features = ["alloc"] }
 pkcs1 = { version = "0.8.0-rc.3", optional = true, default-features = false, features = ["alloc", "pem"] }
 pkcs8 = { version = "0.11.0-rc.6", optional = true, default-features = false, features = ["alloc", "pem"] }
 serdect = { version = "0.3.0", optional = true }
-sha1 = { version = "0.11.0-rc.0", optional = true, default-features = false, features = ["oid"] }
+sha1 = { version = "0.11.0-rc.2", optional = true, default-features = false, features = ["oid"] }
 spki = { version = "0.8.0-rc.4", optional = true, default-features = false, features = ["alloc"] }
-sha2 = { version = "0.11.0-rc.0", optional = true, default-features = false, features = ["oid"] }
+sha2 = { version = "0.11.0-rc.2", optional = true, default-features = false, features = ["oid"] }
 serde = { version = "1.0.184", optional = true, default-features = false, features = ["derive"] }
 
 [dev-dependencies]
@@ -40,9 +40,9 @@ rand_xorshift = "0.4"
 rand_chacha = "0.9"
 rand = "0.9"
 rand_core = { version = "0.9.1", default-features = false }
-sha1 = { version = "0.11.0-rc.0", default-features = false, features = ["oid"] }
-sha2 = { version = "0.11.0-rc.0", default-features = false, features = ["oid"] }
-sha3 = { version = "0.11.0-rc.0", default-features = false, features = ["oid"] }
+sha1 = { version = "0.11.0-rc.2", default-features = false, features = ["oid"] }
+sha2 = { version = "0.11.0-rc.2", default-features = false, features = ["oid"] }
+sha3 = { version = "0.11.0-rc.2", default-features = false, features = ["oid"] }
 hex = { version = "0.4.3", features = ["serde"] }
 serde_json = "1.0.138"
 serde = { version = "1.0.184", features = ["derive"] }
@@ -68,21 +68,3 @@ opt-level = 2
 
 [profile.bench]
 debug = true
-
-[patch.crates-io]
-# https://github.com/RustCrypto/utils/pull/1208
-block-buffer = { git = "https://github.com/RustCrypto/utils" }
-# https://github.com/RustCrypto/utils/pull/1208
-block-padding = { git = "https://github.com/RustCrypto/utils" }
-# https://github.com/RustCrypto/traits/pull/1976
-cipher = { git = "https://github.com/RustCrypto/traits" }
-# https://github.com/RustCrypto/traits/pull/1976
-crypto-common = { git = "https://github.com/RustCrypto/traits" }
-# https://github.com/RustCrypto/block-modes/pull/84
-ctr = { git = "https://github.com/RustCrypto/block-modes" }
-# https://github.com/RustCrypto/traits/pull/1976
-digest = { git = "https://github.com/RustCrypto/traits" }
-# https://github.com/RustCrypto/utils/pull/1208
-inout = { git = "https://github.com/RustCrypto/utils" }
-# https://github.com/RustCrypto/stream-ciphers/pull/450
-salsa20 = { git = "https://github.com/RustCrypto/stream-ciphers" }


### PR DESCRIPTION
Version changes:
 - `block-buffer` to `0.11.0-rc.5`
 - `block-padding` to `0.4.0-rc.4`
 - `cipher` to `0.5.0-rc.1`
 - `crypto-bigint` to `0.7.0-rc.4`
 - `crypto-common` to `0.2.0-rc.4`
 - `ctr` to `0.10.0-rc.1`
 - `digest` to `0.11.0-rc.1`
 - `inout` to `0.2.0-rc.6`
 - `salsa20` to `0.11.0-rc.1`
 - `sha1` to `0.11.0-rc.2`
 - `sha2` to `0.11.0-rc.2`
 - `sha3` to `0.11.0-rc.2`