### PR TITLE
Add minimum `bit_size` of 1024 to `RsaPrivateKey::new`

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -40,6 +40,9 @@ pub enum Error {
     /// Invalid coefficient.
     InvalidCoefficient,
 
+    /// Modulus too small.
+    ModulusTooSmall,
+
     /// Modulus too large.
     ModulusTooLarge,
 
@@ -94,6 +97,7 @@ impl core::fmt::Display for Error {
             Error::InvalidModulus => write!(f, "invalid modulus"),
             Error::InvalidExponent => write!(f, "invalid exponent"),
             Error::InvalidCoefficient => write!(f, "invalid coefficient"),
+            Error::ModulusTooSmall => write!(f, "modulus too small"),
             Error::ModulusTooLarge => write!(f, "modulus too large"),
             Error::PublicExponentTooSmall => write!(f, "public exponent too small"),
             Error::PublicExponentTooLarge => write!(f, "public exponent too large"),

--- a/src/oaep/decrypting_key.rs
+++ b/src/oaep/decrypting_key.rs
@@ -98,7 +98,7 @@ where
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(feature = "serde")]
+    #[cfg(all(feature = "hazmat", feature = "serde"))]
     fn test_serde() {
         use super::*;
         use rand_chacha::{rand_core::SeedableRng, ChaCha8Rng};
@@ -107,7 +107,7 @@ mod tests {
 
         let mut rng = ChaCha8Rng::from_seed([42; 32]);
         let decrypting_key = DecryptingKey::<Sha256>::new(
-            RsaPrivateKey::new(&mut rng, 64).expect("failed to generate key"),
+            RsaPrivateKey::new_unchecked(&mut rng, 64).expect("failed to generate key"),
         );
 
         let tokens = [

--- a/src/oaep/encrypting_key.rs
+++ b/src/oaep/encrypting_key.rs
@@ -73,14 +73,15 @@ where
 mod tests {
 
     #[test]
-    #[cfg(feature = "serde")]
+    #[cfg(all(feature = "hazmat", feature = "serde"))]
     fn test_serde() {
         use super::*;
         use rand_chacha::{rand_core::SeedableRng, ChaCha8Rng};
         use serde_test::{assert_tokens, Configure, Token};
 
         let mut rng = ChaCha8Rng::from_seed([42; 32]);
-        let priv_key = crate::RsaPrivateKey::new(&mut rng, 64).expect("failed to generate key");
+        let priv_key =
+            crate::RsaPrivateKey::new_unchecked(&mut rng, 64).expect("failed to generate key");
         let encrypting_key = EncryptingKey::<sha2::Sha256>::new(priv_key.to_public_key());
 
         let tokens = [

--- a/src/pkcs1v15/decrypting_key.rs
+++ b/src/pkcs1v15/decrypting_key.rs
@@ -56,15 +56,16 @@ impl ZeroizeOnDrop for DecryptingKey {}
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(feature = "serde")]
+    #[cfg(all(feature = "hazmat", feature = "serde"))]
     fn test_serde() {
         use super::*;
         use rand_chacha::{rand_core::SeedableRng, ChaCha8Rng};
         use serde_test::{assert_tokens, Configure, Token};
 
         let mut rng = ChaCha8Rng::from_seed([42; 32]);
-        let decrypting_key =
-            DecryptingKey::new(RsaPrivateKey::new(&mut rng, 64).expect("failed to generate key"));
+        let decrypting_key = DecryptingKey::new(
+            RsaPrivateKey::new_unchecked(&mut rng, 64).expect("failed to generate key"),
+        );
 
         let tokens = [
             Token::Struct {

--- a/src/pkcs1v15/encrypting_key.rs
+++ b/src/pkcs1v15/encrypting_key.rs
@@ -30,14 +30,15 @@ impl RandomizedEncryptor for EncryptingKey {
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(feature = "serde")]
+    #[cfg(all(feature = "hazmat", feature = "serde"))]
     fn test_serde() {
         use super::*;
+        use crate::RsaPrivateKey;
         use rand_chacha::{rand_core::SeedableRng, ChaCha8Rng};
         use serde_test::{assert_tokens, Configure, Token};
 
         let mut rng = ChaCha8Rng::from_seed([42; 32]);
-        let priv_key = crate::RsaPrivateKey::new(&mut rng, 64).expect("failed to generate key");
+        let priv_key = RsaPrivateKey::new_unchecked(&mut rng, 64).expect("failed to generate key");
         let encrypting_key = EncryptingKey::new(priv_key.to_public_key());
 
         let tokens = [

--- a/src/pkcs1v15/signing_key.rs
+++ b/src/pkcs1v15/signing_key.rs
@@ -319,15 +319,16 @@ where
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(feature = "serde")]
+    #[cfg(all(feature = "hazmat", feature = "serde"))]
     fn test_serde() {
         use super::*;
+        use crate::RsaPrivateKey;
         use rand_chacha::{rand_core::SeedableRng, ChaCha8Rng};
         use serde_test::{assert_tokens, Configure, Token};
         use sha2::Sha256;
 
         let mut rng = ChaCha8Rng::from_seed([42; 32]);
-        let priv_key = crate::RsaPrivateKey::new(&mut rng, 64).expect("failed to generate key");
+        let priv_key = RsaPrivateKey::new_unchecked(&mut rng, 64).expect("failed to generate key");
         let signing_key = SigningKey::<Sha256>::new(priv_key);
 
         let tokens = [Token::Str(concat!(

--- a/src/pkcs1v15/verifying_key.rs
+++ b/src/pkcs1v15/verifying_key.rs
@@ -241,15 +241,16 @@ where
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(feature = "serde")]
+    #[cfg(all(feature = "hazmat", feature = "serde"))]
     fn test_serde() {
         use super::*;
+        use crate::RsaPrivateKey;
         use rand_chacha::{rand_core::SeedableRng, ChaCha8Rng};
         use serde_test::{assert_tokens, Configure, Token};
         use sha2::Sha256;
 
         let mut rng = ChaCha8Rng::from_seed([42; 32]);
-        let priv_key = crate::RsaPrivateKey::new(&mut rng, 64).expect("failed to generate key");
+        let priv_key = RsaPrivateKey::new_unchecked(&mut rng, 64).expect("failed to generate key");
         let pub_key = priv_key.to_public_key();
         let verifying_key = VerifyingKey::<Sha256>::new(pub_key);
 

--- a/src/pss/blinded_signing_key.rs
+++ b/src/pss/blinded_signing_key.rs
@@ -279,7 +279,7 @@ where
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(feature = "serde")]
+    #[cfg(all(feature = "hazmat", feature = "serde"))]
     fn test_serde() {
         use super::*;
         use rand_chacha::{rand_core::SeedableRng, ChaCha8Rng};
@@ -288,7 +288,7 @@ mod tests {
 
         let mut rng = ChaCha8Rng::from_seed([42; 32]);
         let signing_key = BlindedSigningKey::<Sha256>::new(
-            RsaPrivateKey::new(&mut rng, 64).expect("failed to generate key"),
+            RsaPrivateKey::new_unchecked(&mut rng, 64).expect("failed to generate key"),
         );
 
         let tokens = [Token::Str(concat!(

--- a/src/pss/signing_key.rs
+++ b/src/pss/signing_key.rs
@@ -312,15 +312,16 @@ where
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(feature = "serde")]
+    #[cfg(all(feature = "hazmat", feature = "serde"))]
     fn test_serde() {
         use super::*;
+        use crate::RsaPrivateKey;
         use rand_chacha::{rand_core::SeedableRng, ChaCha8Rng};
         use serde_test::{assert_tokens, Configure, Token};
         use sha2::Sha256;
 
         let mut rng = ChaCha8Rng::from_seed([42; 32]);
-        let priv_key = crate::RsaPrivateKey::new(&mut rng, 64).expect("failed to generate key");
+        let priv_key = RsaPrivateKey::new_unchecked(&mut rng, 64).expect("failed to generate key");
         let signing_key = SigningKey::<Sha256>::new(priv_key);
 
         let tokens = [Token::Str(concat!(

--- a/src/pss/verifying_key.rs
+++ b/src/pss/verifying_key.rs
@@ -236,15 +236,16 @@ where
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(feature = "serde")]
+    #[cfg(all(feature = "hazmat", feature = "serde"))]
     fn test_serde() {
         use super::*;
+        use crate::RsaPrivateKey;
         use rand_chacha::{rand_core::SeedableRng, ChaCha8Rng};
         use serde_test::{assert_tokens, Configure, Token};
         use sha2::Sha256;
 
         let mut rng = ChaCha8Rng::from_seed([42; 32]);
-        let priv_key = crate::RsaPrivateKey::new(&mut rng, 64).expect("failed to generate key");
+        let priv_key = RsaPrivateKey::new_unchecked(&mut rng, 64).expect("failed to generate key");
         let pub_key = priv_key.to_public_key();
         let verifying_key = VerifyingKey::<Sha256>::new(pub_key);
 

--- a/tests/proptests.rs
+++ b/tests/proptests.rs
@@ -1,5 +1,7 @@
 //! Property-based tests.
 
+#![cfg(feature = "hazmat")]
+
 use proptest::prelude::*;
 use rand_chacha::ChaCha8Rng;
 use rand_core::SeedableRng;
@@ -14,7 +16,7 @@ prop_compose! {
     // WARNING: do *NOT* copy and paste this code. It's insecure and optimized for test speed.
     fn private_key()(seed in any::<[u8; 32]>()) -> RsaPrivateKey {
         let mut rng = ChaCha8Rng::from_seed(seed);
-        RsaPrivateKey::new(&mut rng, 512).unwrap()
+        RsaPrivateKey::new_unchecked(&mut rng, 512).unwrap()
     }
 }
 


### PR DESCRIPTION
Also adds a `hazmat`-gated `RsaPrivateKey::new_unchecked` as an escape hatch.

Partial step towards addressing #445.

cc @pinkforest 