### PR TITLE
Bump `signature` to v3.0.0-rc.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.3"
+version = "3.0.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39195ff4c0dc41c93e123825ca1f0d11b856df8b26d5fe140a522355632c4345"
+checksum = "fc280a6ff65c79fbd6622f64d7127f32b85563bca8c53cd2e9141d6744a9056d"
 dependencies = [
  "digest",
  "rand_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ crypto-bigint = { version = "0.7.0-rc.6", default-features = false, features = [
 crypto-primes = { version = "0.7.0-pre.2", default-features = false }
 digest = { version = "0.11.0-rc.1", default-features = false, features = ["alloc", "oid"] }
 rand_core = { version = "0.9", default-features = false }
-signature = { version = "3.0.0-rc.3", default-features = false, features = ["alloc", "digest", "rand_core"] }
+signature = { version = "3.0.0-rc.4", default-features = false, features = ["alloc", "digest", "rand_core"] }
 subtle = { version = "2.6.1", default-features = false }
 zeroize = { version = "1.5", features = ["alloc"] }
 

--- a/src/pss.rs
+++ b/src/pss.rs
@@ -398,10 +398,13 @@ tAboUGBxTDq3ZroNism3DaMIbKPyYrAqhKov1h5V
         let verifying_key = VerifyingKey::new(pub_key);
 
         for (text, sig, expected) in &tests {
-            let mut digest = Sha1::new();
-            digest.update(text.as_bytes());
-            let result =
-                verifying_key.verify_digest(digest, &Signature::try_from(sig.as_slice()).unwrap());
+            let result = verifying_key.verify_digest(
+                |digest: &mut Sha1| {
+                    digest.update(text.as_bytes());
+                    Ok(())
+                },
+                &Signature::try_from(sig.as_slice()).unwrap(),
+            );
             match expected {
                 true => result.expect("failed to verify"),
                 false => {
@@ -495,14 +498,17 @@ tAboUGBxTDq3ZroNism3DaMIbKPyYrAqhKov1h5V
         let verifying_key = signing_key.verifying_key();
 
         for test in &tests {
-            let mut digest = Sha1::new();
-            digest.update(test.as_bytes());
-            let sig = signing_key.sign_digest_with_rng(&mut rng, digest);
+            let sig = signing_key
+                .sign_digest_with_rng(&mut rng, |digest: &mut Sha1| digest.update(test.as_bytes()));
 
-            let mut digest = Sha1::new();
-            digest.update(test.as_bytes());
             verifying_key
-                .verify_digest(digest, &sig)
+                .verify_digest(
+                    |digest: &mut Sha1| {
+                        digest.update(test.as_bytes());
+                        Ok(())
+                    },
+                    &sig,
+                )
                 .expect("failed to verify");
         }
     }
@@ -517,14 +523,17 @@ tAboUGBxTDq3ZroNism3DaMIbKPyYrAqhKov1h5V
         let verifying_key = signing_key.verifying_key();
 
         for test in &tests {
-            let mut digest = Sha1::new();
-            digest.update(test.as_bytes());
-            let sig = signing_key.sign_digest_with_rng(&mut rng, digest);
+            let sig = signing_key
+                .sign_digest_with_rng(&mut rng, |digest: &mut Sha1| digest.update(test.as_bytes()));
 
-            let mut digest = Sha1::new();
-            digest.update(test.as_bytes());
             verifying_key
-                .verify_digest(digest, &sig)
+                .verify_digest(
+                    |digest: &mut Sha1| {
+                        digest.update(test.as_bytes());
+                        Ok(())
+                    },
+                    &sig,
+                )
                 .expect("failed to verify");
         }
     }


### PR DESCRIPTION
This brings `*DigestSigner`/`*DigestVerifier` changes introduced in RustCrypto/traits#2004