### PR TITLE
fixup support for `subtle` feature in `hybrid-array`

### DIFF
--- a/src/algorithms/pss.rs
+++ b/src/algorithms/pss.rs
@@ -372,7 +372,7 @@ where
     let h0 = hash.finalize_reset();
 
     // 14. If H = H', output "consistent." Otherwise, output "inconsistent."
-    if (salt_valid & h0.ct_eq(h)).into() {
+    if (salt_valid & h0.as_slice().ct_eq(h)).into() {
         Ok(())
     } else {
         Err(Error::Verification)


### PR DESCRIPTION
When a downstream crate enables the `subtle` feature in `hybrid-array`, the crate would fail to compile:
```
src/algorithms/pss.rs:375:31
    |
375 |     if (salt_valid & h0.ct_eq(h)).into() {
    |                         ----- ^ expected `&Array<u8, ...>`, found `&mut [u8]`
    |                         |
    |                         arguments to this method are incorrect
    |
    = note:      expected reference `&Array<u8, <D as OutputSizeUser>::OutputSize>`
            found mutable reference `&mut [u8]`
```

This is because the `hybrid_array::Array` was automatically deref'ed to a slice. Now `Array` implements `subtle::ConstantTimeEq` that automatic deref no longer happens.

This commit fixes that by converting one of the arguments of the conversion that brings back the auto-deref.

Thanks to @tarcieri for the help debugging: https://github.com/RustCrypto/formats/pull/2049#issuecomment-3349728130