### PR TITLE
pss, oaep: remove DynDigest

### DIFF
--- a/src/algorithms/mgf.rs
+++ b/src/algorithms/mgf.rs
@@ -1,11 +1,14 @@
 //! Mask generation function common to both PSS and OAEP padding
 
-use digest::{Digest, DynDigest, FixedOutputReset};
+use digest::{Digest, FixedOutputReset};
 
 /// Mask generation function.
 ///
 /// Panics if out is larger than 2**32. This is in accordance with RFC 8017 - PKCS #1 B.2.1
-pub(crate) fn mgf1_xor(out: &mut [u8], digest: &mut dyn DynDigest, seed: &[u8]) {
+pub(crate) fn mgf1_xor<D>(out: &mut [u8], digest: &mut D, seed: &[u8])
+where
+    D: Digest + FixedOutputReset,
+{
     let mut counter = [0u8; 4];
     let mut i = 0;
 
@@ -17,7 +20,7 @@ pub(crate) fn mgf1_xor(out: &mut [u8], digest: &mut dyn DynDigest, seed: &[u8]) 
         digest_input[0..seed.len()].copy_from_slice(seed);
         digest_input[seed.len()..].copy_from_slice(&counter);
 
-        digest.update(digest_input.as_slice());
+        Digest::update(digest, digest_input.as_slice());
         let digest_output = &*digest.finalize_reset();
         let mut j = 0;
         loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,12 +34,12 @@
 //!
 //! // Encrypt
 //! let data = b"hello world";
-//! let padding = Oaep::new::<Sha256>();
+//! let padding = Oaep::<Sha256>::new();
 //! let enc_data = public_key.encrypt(&mut rng, padding, &data[..]).expect("failed to encrypt");
 //! assert_ne!(&data[..], &enc_data[..]);
 //!
 //! // Decrypt
-//! let padding = Oaep::new::<Sha256>();
+//! let padding = Oaep::<Sha256>::new();
 //! let dec_data = private_key.decrypt(padding, &enc_data).expect("failed to decrypt");
 //! assert_eq!(&data[..], &dec_data[..]);
 //! ```


### PR DESCRIPTION
I'm not sure I see why usage of `DynDigest` was originally introduced. The need to make the Digest also Send is hard to use in downstream crates.
I don't believe this was necessary, this removes its use and makes the consumer specify the Digest types.