### PR TITLE
Support for cryptographic operations with larger keys

### DIFF
--- a/src/pkcs1v15.rs
+++ b/src/pkcs1v15.rs
@@ -142,7 +142,7 @@ fn encrypt<R: CryptoRngCore + ?Sized>(
     pub_key: &RsaPublicKey,
     msg: &[u8],
 ) -> Result<Vec<u8>> {
-    key::check_public_with_max_size(pub_key, pub_key.max_size)?;
+    key::check_public(pub_key)?;
 
     let em = pkcs1v15_encrypt_pad(rng, msg, pub_key.size())?;
     let int = Zeroizing::new(BigUint::from_bytes_be(&em));
@@ -164,7 +164,7 @@ fn decrypt<R: CryptoRngCore + ?Sized>(
     priv_key: &RsaPrivateKey,
     ciphertext: &[u8],
 ) -> Result<Vec<u8>> {
-    key::check_public_with_max_size(priv_key,priv_key.pubkey_components.max_size)?;
+    key::check_public(priv_key)?;
 
     let em = rsa_decrypt_and_check(priv_key, rng, &BigUint::from_bytes_be(ciphertext))?;
     let em = uint_to_zeroizing_be_pad(em, priv_key.size())?;


### PR DESCRIPTION
Currently, this crate allows instantiation of public keys larger than 4096 bit (via `RsaPublicKey::new_with_max_size`), but doing cryptographic operations with such public keys fails in `key::check_public`, which always checks the modulus size against the constant `RsaPublicKey::MAX_SIZE`.

Also, there's no public API to instantiate larger private keys, or to do cryptographic operations with them.

I think it would be nice to cap both public and private key sizes to 4096 bit by default, but to allow opt-in creation of larger keys (complete with working cryptographic operations).