### PR TITLE
Bump `crypto-bigint` dependency to v0.7.0-rc.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,8 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack test --release --feature-powerset --exclude-features os_rng,serde
-      - run: cargo test --release --features os_rng
+      - run: cargo hack test --release --feature-powerset --exclude-features getrandom,serde
+      - run: cargo test --release --features getrandom
       - run: cargo test --release --features serde
 
   minimal-versions:
@@ -66,7 +66,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
       - run: cargo update -Z minimal-versions
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo test --release --features os_rng,serde,pkcs5
+      - run: cargo test --release --features getrandom,serde,pkcs5
 
   nightly:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,13 +120,13 @@ checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-rc.3"
+version = "0.10.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3585020fc6766ef7ff5c58d69819dbca16a19008ae347bb5d3e4e145c495eb38"
+checksum = "f895fb33c1ad22da4bc79d37c0bddff8aee2ba4575705345eb73b8ffbc386074"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "rand_core 0.10.0-rc-2",
+ "rand_core 0.10.0-rc-3",
 ]
 
 [[package]]
@@ -139,6 +139,12 @@ dependencies = [
  "crypto-common",
  "inout",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11ed919bd3bae4af5ab56372b627dfc32622aba6cec36906e8ab46746037c9d"
 
 [[package]]
 name = "const-oid"
@@ -157,35 +163,37 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.10"
+version = "0.7.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6715836b4946e8585016e80b79c7561476aff3b22f7b756778e7b109d86086c6"
+checksum = "a7ddf7876857d903765f30de7c789044ea2e49a4f611fe96416827175cef6b34"
 dependencies = [
+ "ctutils",
+ "getrandom 0.4.0-rc.0",
  "num-traits",
- "rand_core 0.10.0-rc-2",
+ "rand_core 0.10.0-rc-3",
  "serdect",
- "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919bd05924682a5480aec713596b9e2aabed3a0a6022fab6847f85a99e5f190a"
+checksum = "e6165b8029cdc3e765b74d3548f85999ee799d5124877ce45c2c85ca78e4d4aa"
 dependencies = [
+ "getrandom 0.4.0-rc.0",
  "hybrid-array",
+ "rand_core 0.10.0-rc-3",
 ]
 
 [[package]]
 name = "crypto-primes"
-version = "0.7.0-pre.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd9b2855017318a49714c07ee8895b89d3510d54fa6d86be5835de74c389609"
+version = "0.7.0-dev"
+source = "git+https://github.com/tarcieri/crypto-primes?branch=crypto-bigint%2Fv0.7.0-rc.12#a96b3c9e40db97dfd3df73d9368ff096292fcb16"
 dependencies = [
  "crypto-bigint",
  "libm",
- "rand_core 0.10.0-rc-2",
+ "rand_core 0.10.0-rc-3",
 ]
 
 [[package]]
@@ -195,6 +203,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0ec605a95e78815a4c4b8040217d56d5a1ab37043851ee9e7e65b89afa00e3"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925ebe186f09a7894817213f89eae07c39374f5c934613605af7accc8aea6414"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -301,6 +318,19 @@ dependencies = [
  "libc",
  "r-efi",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b99f0d993a2b9b97b9a201193aa8ad21305cde06a3be9a7e1f8f4201e5cc27e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "rand_core 0.10.0-rc-3",
+ "wasip2",
 ]
 
 [[package]]
@@ -483,7 +513,7 @@ dependencies = [
  "cbc",
  "der",
  "pbkdf2",
- "rand_core 0.10.0-rc-2",
+ "rand_core 0.10.0-rc-3",
  "scrypt",
  "sha2",
  "spki",
@@ -497,7 +527,7 @@ checksum = "77089aec8290d0b7bb01b671b091095cf1937670725af4fd73d47249f03b12c0"
 dependencies = [
  "der",
  "pkcs5",
- "rand_core 0.10.0-rc-2",
+ "rand_core 0.10.0-rc-3",
  "spki",
 ]
 
@@ -591,13 +621,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7d245ced4538f0406b1579d3d4a6515a2ff1bdf20733492e2e4fc90a648769"
+version = "0.10.0-rc.5"
+source = "git+https://github.com/rust-random/rand#ff07ec205347dd749a586aaee7218cb21590ea4c"
 dependencies = [
  "chacha20",
- "getrandom",
- "rand_core 0.10.0-rc-2",
+ "getrandom 0.4.0-rc.0",
+ "rand_core 0.10.0-rc-3",
 ]
 
 [[package]]
@@ -616,14 +645,14 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.10.0-rc-2"
+version = "0.10.0-rc-3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104a23e4e8b77312a823b6b5613edbac78397e2f34320bc7ac4277013ec4478e"
+checksum = "f66ee92bc15280519ef199a274fe0cafff4245d31bc39aaa31c011ad56cb1f05"
 
 [[package]]
 name = "rand_xorshift"
@@ -676,6 +705,7 @@ dependencies = [
  "base64ct",
  "const-oid",
  "crypto-bigint",
+ "crypto-common",
  "crypto-primes",
  "digest",
  "hex",
@@ -683,8 +713,8 @@ dependencies = [
  "pkcs1",
  "pkcs8",
  "proptest",
- "rand 0.10.0-rc.1",
- "rand_core 0.10.0-rc-2",
+ "rand 0.10.0-rc.5",
+ "rand_core 0.10.0-rc-3",
  "rstest",
  "serde",
  "serde_json",
@@ -695,7 +725,6 @@ dependencies = [
  "sha3",
  "signature",
  "spki",
- "subtle",
  "zeroize",
 ]
 
@@ -896,7 +925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0251c9d6468f4ba853b6352b190fb7c1e405087779917c238445eb03993826"
 dependencies = [
  "digest",
- "rand_core 0.10.0-rc-2",
+ "rand_core 0.10.0-rc-3",
 ]
 
 [[package]]
@@ -939,7 +968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,15 @@ exclude = ["marvin_toolkit/", "thirdparty/"]
 
 [dependencies]
 const-oid = { version = "0.10", default-features = false }
-crypto-bigint = { version = "0.7.0-rc.10", default-features = false, features = ["zeroize", "alloc"] }
-crypto-primes = { version = "0.7.0-pre.4", default-features = false }
+crypto-bigint = { version = "0.7.0-rc.12", default-features = false, features = ["zeroize", "alloc"] }
+crypto-primes = { version = "0.7.0-dev", default-features = false }
 digest = { version = "0.11.0-rc.4", default-features = false, features = ["alloc", "oid"] }
 rand_core = { version = "0.10.0-rc-2", default-features = false }
 signature = { version = "3.0.0-rc.5", default-features = false, features = ["alloc", "digest", "rand_core"] }
-subtle = { version = "2.6.1", default-features = false }
 zeroize = { version = "1.8", features = ["alloc"] }
 
 # optional dependencies
+crypto-common = { version = "0.2.0-rc.8", optional = true, features = ["getrandom"] }
 pkcs1 = { version = "0.8.0-rc.3", optional = true, default-features = false, features = ["alloc", "pem"] }
 pkcs8 = { version = "0.11.0-rc.8", optional = true, default-features = false, features = ["alloc", "pem"] }
 serdect = { version = "0.4", optional = true }
@@ -31,15 +31,14 @@ sha1 = { version = "0.11.0-rc.3", optional = true, default-features = false, fea
 sha2 = { version = "0.11.0-rc.3", optional = true, default-features = false, features = ["oid"] }
 spki = { version = "0.8.0-rc.4", optional = true, default-features = false, features = ["alloc"] }
 serde = { version = "1.0.184", optional = true, default-features = false, features = ["derive"] }
-rand = { version = "0.10.0-rc.1", optional = true, default-features = false }
 
 [dev-dependencies]
 base64ct = { version = "1", features = ["alloc"] }
 hex-literal = "1"
 proptest = "1"
 serde_test = "1.0.89"
-rand = { version = "0.10.0-rc.1", features = ["chacha"] }
-rand_core = { version = "0.10.0-rc-2", default-features = false }
+rand = { version = "0.10.0-rc.5", features = ["chacha"] }
+rand_core = { version = "0.10.0-rc-3", default-features = false }
 sha1 = { version = "0.11.0-rc.3", default-features = false, features = ["oid"] }
 sha2 = { version = "0.11.0-rc.3", default-features = false, features = ["oid"] }
 sha3 = { version = "0.11.0-rc.3", default-features = false, features = ["oid"] }
@@ -55,10 +54,10 @@ name = "key"
 default = ["std", "encoding"]
 encoding = ["dep:pkcs1", "dep:pkcs8", "dep:spki"]
 hazmat = []
-os_rng = ["crypto-bigint/rand_core", "rand/os_rng"]
+getrandom = ["crypto-bigint/getrandom", "crypto-common"]
 serde = ["encoding", "dep:serde", "dep:serdect", "crypto-bigint/serde"]
 pkcs5 = ["pkcs8/encryption"]
-std = ["pkcs1?/std", "pkcs8?/std", "crypto-bigint/rand"]
+std = ["pkcs1?/std", "pkcs8?/std"]
 
 [package.metadata.docs.rs]
 features = ["std", "serde", "hazmat", "sha2"]
@@ -69,3 +68,7 @@ opt-level = 2
 
 [profile.bench]
 debug = true
+
+[patch.crates-io]
+crypto-primes = { git = "https://github.com/tarcieri/crypto-primes", branch = "crypto-bigint/v0.7.0-rc.12" }
+rand = { git = "https://github.com/rust-random/rand" }

--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -184,7 +184,7 @@ fn blind<R: TryCryptoRng + ?Sized, K: PublicKeyParts>(
     let mut r: BoxedUint = BoxedUint::one_with_precision(bits);
     let mut ir: Option<BoxedUint> = None;
     while ir.is_none() {
-        r = BoxedUint::try_random_mod(rng, key.n()).map_err(|_| Error::Rng)?;
+        r = BoxedUint::try_random_mod_vartime(rng, key.n()).map_err(|_| Error::Rng)?;
         if r.is_zero().into() {
             r = BoxedUint::one_with_precision(bits);
         }

--- a/src/key.rs
+++ b/src/key.rs
@@ -52,8 +52,9 @@ impl Hash for RsaPublicKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
         // Domain separator for RSA private keys
         state.write(b"RsaPublicKey");
-        Hash::hash(&self.n, state);
-        Hash::hash(&self.e, state);
+        // TODO(tarcieri): to match the `PartialEq` impl we should strip leading zeros
+        Hash::hash(&self.n.as_limbs(), state);
+        Hash::hash(&self.e.as_limbs(), state);
     }
 }
 

--- a/src/pss/signing_key.rs
+++ b/src/pss/signing_key.rs
@@ -27,9 +27,9 @@ use {
     },
 };
 
-#[cfg(feature = "os_rng")]
+#[cfg(feature = "getrandom")]
 use {
-    rand::rngs::OsRng,
+    crypto_common::SysRng,
     signature::{hazmat::PrehashSigner, MultipartSigner, Signer},
 };
 
@@ -162,33 +162,33 @@ where
     }
 }
 
-#[cfg(feature = "os_rng")]
+#[cfg(feature = "getrandom")]
 impl<D> PrehashSigner<Signature> for SigningKey<D>
 where
     D: Digest + FixedOutputReset,
 {
     fn sign_prehash(&self, prehash: &[u8]) -> signature::Result<Signature> {
-        self.sign_prehash_with_rng(&mut OsRng, prehash)
+        self.sign_prehash_with_rng(&mut SysRng, prehash)
     }
 }
 
-#[cfg(feature = "os_rng")]
+#[cfg(feature = "getrandom")]
 impl<D> Signer<Signature> for SigningKey<D>
 where
     D: Digest + FixedOutputReset,
 {
     fn try_sign(&self, msg: &[u8]) -> signature::Result<Signature> {
-        self.try_sign_with_rng(&mut OsRng, msg)
+        self.try_sign_with_rng(&mut SysRng, msg)
     }
 }
 
-#[cfg(feature = "os_rng")]
+#[cfg(feature = "getrandom")]
 impl<D> MultipartSigner<Signature> for SigningKey<D>
 where
     D: Digest + FixedOutputReset,
 {
     fn try_multipart_sign(&self, msg: &[&[u8]]) -> signature::Result<Signature> {
-        self.try_multipart_sign_with_rng(&mut OsRng, msg)
+        self.try_multipart_sign_with_rng(&mut SysRng, msg)
     }
 }
 

--- a/tests/pkcs1.rs
+++ b/tests/pkcs1.rs
@@ -2,14 +2,13 @@
 
 #![cfg(feature = "encoding")]
 
-use crypto_bigint::BoxedUint;
+use crypto_bigint::{BoxedUint, CtEq};
 use hex_literal::hex;
 use rsa::{
     pkcs1::{DecodeRsaPrivateKey, DecodeRsaPublicKey, EncodeRsaPrivateKey, EncodeRsaPublicKey},
     traits::{PrivateKeyParts, PublicKeyParts},
     RsaPrivateKey, RsaPublicKey,
 };
-use subtle::ConstantTimeEq;
 
 #[cfg(feature = "encoding")]
 use rsa::pkcs1::LineEnding;

--- a/tests/pkcs8.rs
+++ b/tests/pkcs8.rs
@@ -2,7 +2,7 @@
 
 #![cfg(feature = "encoding")]
 
-use crypto_bigint::BoxedUint;
+use crypto_bigint::{BoxedUint, CtEq};
 use hex_literal::hex;
 use rsa::{
     pkcs1v15,
@@ -12,7 +12,6 @@ use rsa::{
     RsaPrivateKey, RsaPublicKey,
 };
 use sha2::Sha256;
-use subtle::ConstantTimeEq;
 
 #[cfg(feature = "encoding")]
 use rsa::pkcs8::LineEnding;


### PR DESCRIPTION
This release migrates from `subtle` to the new `ctutils` library, which should improve constant-time properties.

It also brings a new `rand_core` release and the first new `getrandom` series prerelease: v0.4.0-rc.0, which makes it possible to remove the direct dependency on `rand`.

I've pulled `getrandom` in through an optional dependency on `crypto-common`, as I'd like to impl the `Generate` trait in a followup.

Finally, as noted earlier `crypto-common` has migrated to `ctutils`, so this also removes the direct dependency on `subtle`, replacing it with the same-named types from `ctutils` which act as a mostly drop-in replacement.