### PR TITLE
Bump `crypto-bigint` to v0.7.0-rc.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.12"
+version = "0.7.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ddf7876857d903765f30de7c789044ea2e49a4f611fe96416827175cef6b34"
+checksum = "b2bb4138de6db76c8155b4423e967049fbef2cf84ad6af7f552f73a161941b72"
 dependencies = [
  "ctutils",
  "getrandom 0.4.0-rc.0",
@@ -207,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925ebe186f09a7894817213f89eae07c39374f5c934613605af7accc8aea6414"
+checksum = "130ffe18bdf7a4926e57ed19d404995244e6c8d6a97abf4eddde1f892bf1ce0c"
 dependencies = [
  "cmov",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["marvin_toolkit/", "thirdparty/"]
 
 [dependencies]
 const-oid = { version = "0.10", default-features = false }
-crypto-bigint = { version = "0.7.0-rc.12", default-features = false, features = ["zeroize", "alloc"] }
+crypto-bigint = { version = "0.7.0-rc.13", default-features = false, features = ["zeroize", "alloc"] }
 crypto-primes = { version = "0.7.0-dev", default-features = false }
 digest = { version = "0.11.0-rc.4", default-features = false, features = ["alloc", "oid"] }
 rand_core = { version = "0.10.0-rc-2", default-features = false }


### PR DESCRIPTION
This release bumps `ctutils` to v0.3, which eliminated the `Choice::new` constructor in favor of the more explicit `Choice::from_u8_lsb`.

This updates `crypto-bigint` and gets rid of the remaining usages of `Crypto::new`.