### PR TITLE
Bump `crypto-bigint` to v0.7.0-rc.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.13"
+version = "0.7.0-rc.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2bb4138de6db76c8155b4423e967049fbef2cf84ad6af7f552f73a161941b72"
+checksum = "fbd828c64d6fecf364ec127641e5ce0f8d6e3264a6c466b4a4bdcbec5b038b9e"
 dependencies = [
  "ctutils",
  "getrandom 0.4.0-rc.0",
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-primes"
-version = "0.7.0-pre.5"
+version = "0.7.0-pre.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0b07a7a616370e8b6efca0c6a25e5f4c6d02fde11f3d570e4af64d8ed7e2e9"
+checksum = "e79c98a281f9441200b24e3151407a629bfbe720399186e50516da939195e482"
 dependencies = [
  "crypto-bigint",
  "libm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ exclude = ["marvin_toolkit/", "thirdparty/"]
 
 [dependencies]
 const-oid = { version = "0.10", default-features = false }
-crypto-bigint = { version = "0.7.0-rc.13", default-features = false, features = ["zeroize", "alloc"] }
-crypto-primes = { version = "0.7.0-pre.5", default-features = false }
+crypto-bigint = { version = "0.7.0-rc.16", default-features = false, features = ["zeroize", "alloc"] }
+crypto-primes = { version = "0.7.0-pre.6", default-features = false }
 digest = { version = "0.11.0-rc.4", default-features = false, features = ["alloc", "oid"] }
 rand_core = { version = "0.10.0-rc-2", default-features = false }
 signature = { version = "3.0.0-rc.5", default-features = false, features = ["alloc", "digest", "rand_core"] }

--- a/src/key.rs
+++ b/src/key.rs
@@ -525,7 +525,7 @@ impl RsaPrivateKey {
             Ordering::Equal => &q % NonZero::new(p.clone()).expect("`p` is non-zero"),
         };
 
-        let q_mod_p = BoxedMontyForm::new(q_mod_p, p_params.clone());
+        let q_mod_p = BoxedMontyForm::new(q_mod_p, &p_params);
         let qinv = q_mod_p.invert().into_option().ok_or(Error::InvalidPrime)?;
 
         debug_assert_eq!(dp.bits_precision(), p.bits_precision());


### PR DESCRIPTION
This includes changes to `BoxedMontyForm::new` that handle cloning the `Arc` around the `BoxedMontyParams` internally, rather than requiring the caller to clone it.

It also renames the unchecked square root to `floor_sqrt`, which is fine for the one usage here (in the prime recovery implementation), because it immediately performs a check on the result.