### PR TITLE
Bump `sha1`, `sha2`, and `sha3` to v0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ crypto-common = { version = "0.2", optional = true, features = ["getrandom"] }
 pkcs1 = { version = "0.8.0-rc.4", optional = true, default-features = false, features = ["alloc", "pem"] }
 pkcs8 = { version = "0.11.0-rc.10", optional = true, default-features = false, features = ["alloc", "pem"] }
 serdect = { version = "0.4", optional = true }
-sha1 = { version = "0.11.0-rc.5", optional = true, default-features = false, features = ["oid"] }
-sha2 = { version = "0.11.0-rc.5", optional = true, default-features = false, features = ["oid"] }
+sha1 = { version = "0.11", optional = true, default-features = false, features = ["oid"] }
+sha2 = { version = "0.11", optional = true, default-features = false, features = ["oid"] }
 spki = { version = "0.8.0-rc.4", optional = true, default-features = false, features = ["alloc"] }
 serde = { version = "1.0.184", optional = true, default-features = false, features = ["derive"] }
 
@@ -39,9 +39,9 @@ proptest = "1"
 serde_test = "1.0.89"
 rand = { version = "0.10", features = ["chacha"] }
 rand_core = { version = "0.10", default-features = false }
-sha1 = { version = "0.11.0-rc.5", default-features = false, features = ["oid"] }
-sha2 = { version = "0.11.0-rc.5", default-features = false, features = ["oid"] }
-sha3 = { version = "0.11.0-rc.8", default-features = false, features = ["oid"] }
+sha1 = { version = "0.11", default-features = false, features = ["oid"] }
+sha2 = { version = "0.11", default-features = false, features = ["oid"] }
+sha3 = { version = "0.11", default-features = false, features = ["oid"] }
 hex = { version = "0.4.3", features = ["serde"] }
 serde_json = "1.0.138"
 serde = { version = "1.0.184", features = ["derive"] }
@@ -52,12 +52,13 @@ name = "key"
 
 [features]
 default = ["std", "encoding"]
+std = ["pkcs1?/std", "pkcs8?/std"]
+
 encoding = ["dep:pkcs1", "dep:pkcs8", "dep:spki"]
 hazmat = []
 getrandom = ["crypto-bigint/getrandom", "crypto-common"]
 serde = ["encoding", "dep:serde", "dep:serdect", "crypto-bigint/serde"]
 pkcs5 = ["pkcs8/encryption"]
-std = ["pkcs1?/std", "pkcs8?/std"]
 
 [package.metadata.docs.rs]
 features = ["std", "serde", "hazmat", "sha2"]


### PR DESCRIPTION
These are the final releases of these hash crates.

Release PRs:
- `sha1`: RustCrypto/hashes#810
- `sha2`: RustCrypto/hashes#806
- `sha3`: RustCrypto/hashes#816