### PR TITLE
Bump `pkcs8` depenency to v0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.12"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d71d6da5a0e652b5c694049095a52f5e564012b8ee5001cf10d84a4ca9a7f9d"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
  "der",
  "pkcs5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ zeroize = { version = "1.8", features = ["alloc"] }
 # optional dependencies
 crypto-common = { version = "0.2", optional = true, features = ["getrandom"] }
 pkcs1 = { version = "0.8.0-rc.4", optional = true, default-features = false, features = ["alloc", "pem"] }
-pkcs8 = { version = "0.11.0-rc.12", optional = true, default-features = false, features = ["alloc", "pem"] }
+pkcs8 = { version = "0.11", optional = true, default-features = false, features = ["alloc", "pem"] }
 serdect = { version = "0.4", optional = true }
 sha1 = { version = "0.11", optional = true, default-features = false, features = ["oid"] }
 sha2 = { version = "0.11", optional = true, default-features = false, features = ["oid"] }


### PR DESCRIPTION
Relese PR: RustCrypto/formats#2314