### PR TITLE
Reject PSS salt lengths that do not fit in a u8

### DIFF
--- a/src/pss.rs
+++ b/src/pss.rs
@@ -39,7 +39,10 @@ use {
     crate::encoding::ID_RSASSA_PSS,
     const_oid::AssociatedOid,
     pkcs1::RsaPssParams,
-    spki::{der::Any, AlgorithmIdentifierOwned},
+    spki::{
+        der::{Any, ErrorKind},
+        AlgorithmIdentifierOwned,
+    },
 };
 
 /// Digital signatures using PSS padding.
@@ -272,15 +275,16 @@ pub fn get_default_pss_signature_algo_id<D>() -> spki::Result<AlgorithmIdentifie
 where
     D: Digest + AssociatedOid,
 {
-    let salt_len: u8 = <D as Digest>::output_size() as u8;
-    get_pss_signature_algo_id::<D>(salt_len)
+    get_pss_signature_algo_id::<D>(<D as Digest>::output_size())
 }
 
 #[cfg(feature = "encoding")]
-fn get_pss_signature_algo_id<D>(salt_len: u8) -> spki::Result<AlgorithmIdentifierOwned>
+fn get_pss_signature_algo_id<D>(salt_len: usize) -> spki::Result<AlgorithmIdentifierOwned>
 where
     D: Digest + AssociatedOid,
 {
+    // RsaPssParams encodes salt_len in a single byte; reject rather than truncate.
+    let salt_len = u8::try_from(salt_len).map_err(|_| ErrorKind::Overflow.to_error())?;
     let pss_params = RsaPssParams::new::<D>(salt_len);
 
     Ok(AlgorithmIdentifierOwned {
@@ -671,5 +675,25 @@ tAboUGBxTDq3ZroNism3DaMIbKPyYrAqhKov1h5V
                 .verify(test.as_bytes(), &sig)
                 .expect("verification to succeed");
         }
+    }
+
+    // A salt length that does not fit in a byte must be rejected, not truncated (#703).
+    #[test]
+    fn signature_algorithm_identifier_rejects_oversized_salt_len() {
+        use spki::DynSignatureAlgorithmIdentifier;
+
+        let priv_key = get_private_key();
+
+        // largest value that fits in a byte
+        let ok_key = SigningKey::<Sha1>::new_with_salt_len(priv_key.clone(), 255);
+        assert!(ok_key.signature_algorithm_identifier().is_ok());
+
+        // would wrap to 0
+        let bad_key = SigningKey::<Sha1>::new_with_salt_len(priv_key.clone(), 256);
+        assert!(bad_key.signature_algorithm_identifier().is_err());
+
+        // blinded key uses the same path
+        let bad_blinded = BlindedSigningKey::<Sha1>::new_with_salt_len(priv_key, 256);
+        assert!(bad_blinded.signature_algorithm_identifier().is_err());
     }
 }

--- a/src/pss/blinded_signing_key.rs
+++ b/src/pss/blinded_signing_key.rs
@@ -184,7 +184,7 @@ where
     D: Digest + AssociatedOid,
 {
     fn signature_algorithm_identifier(&self) -> spki::Result<AlgorithmIdentifierOwned> {
-        get_pss_signature_algo_id::<D>(self.salt_len as u8)
+        get_pss_signature_algo_id::<D>(self.salt_len)
     }
 }
 

--- a/src/pss/signing_key.rs
+++ b/src/pss/signing_key.rs
@@ -221,7 +221,7 @@ where
     D: Digest + AssociatedOid,
 {
     fn signature_algorithm_identifier(&self) -> spki::Result<AlgorithmIdentifierOwned> {
-        get_pss_signature_algo_id::<D>(self.salt_len as u8)
+        get_pss_signature_algo_id::<D>(self.salt_len)
     }
 }
 


### PR DESCRIPTION
Fixes #703.

The problem: When signing with RSA-PSS, the signature includes metadata that records the salt length so verifiers know how to validate it. That field is encoded as a single byte, meaning it can only represent values from 0 to 255. The code previously wrote the salt length into that byte without checking whether it fit, so values of 256 or greater silently wrapped around (256 became 0, 257 became 1, and so on). As a result, the encoded salt length no longer matched the one actually used to generate the signature, causing every such signature to fail verification without any indication of why.

The fix: Validate that the configured salt length fits within a single byte before encoding it. If it exceeds 255, return a clear error instead of producing an invalid signature. Since both the standard signing key and the blinded signing key share the same encoding path, the validation applies to both automatically.

Tests: Added a regression test covering the boundary conditions by verifying that a salt length of 255 still succeeds, 256 is rejected with an error, and the blinded signing key exhibits the same behavior. I also confirmed the test fails if the previous behavior is restored, ensuring it protects against future regressions.

---
Fixes #703 will auto-close the issue when the PR merges. If you'd rather it not auto-close, change it to Refs #703.